### PR TITLE
Add extraArgs into StatefulSet

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.16.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.12.11
+version: 3.12.12
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -113,6 +113,9 @@ spec:
             {{- if .Values.config }}
             - --config=/etc/atlantis/atlantis.yaml
             {{- end }}
+            {{- if .Values.extraArgs }}
+            {{ toYaml .Values.extraArgs | indent 12 | trim }}
+            {{- end }}
           ports:
           - name: atlantis
             containerPort: 4141

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -286,3 +286,8 @@ initContainers: []
 # - name: example
 #   image: alpine:latest
 #   command: ['sh', '-c', 'echo The init container is running! && sleep 10']
+
+extraArgs: []
+# extraArgs:
+# - --disable-autoplan
+# - --disable-repo-locking


### PR DESCRIPTION
Hello, this PR adds `extraArgs` support into Atlantis running container. 

This is a pattern commonly used by other opensource charts:
* https://github.com/prometheus-community/helm-charts/blob/b0ebaff7c3dc5e9038e0dc5a4931b8b7ba18fad2/charts/kube-prometheus-stack/values.yaml#L1251
* https://github.com/bitnami/charts/blob/c2ac165a579a8f06dede2b6fede2f4ec2bfea495/bitnami/kube-prometheus/values.yaml#L1351
* https://github.com/traefik/traefik-helm-chart/blob/bbad36d8b871e35f1c2290b1a033d2f01c9a94ab/traefik/values.yaml#L119

I made this because we want to use the `--disable-repo-locking` argument introduced in Atlantis v0.16.1