### PR TITLE
Add host aliases as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ The following options are supported.  See [values.yaml](values.yaml) for more de
 | `test.enabled`                              | Whether to enable the test. | `true` |
 | `extraManifests`                         | add additional manifests to deploy                      | `[]`                      |
 | `initContainers`                            | Containers used to initialize context for Atlantis pods                                  | `[]`                              |
+| `hostAliases[].hostnames`                            | Hostnames for host alias entry                                  | n/a                              |
+| `hostAliases[].ip`                            | IP for host alias entry                                  | `n/a                              |
 
 **NOTE**: All the [Server Configurations](https://www.runatlantis.io/docs/server-configuration.html) are passed as [Environment Variables](https://www.runatlantis.io/docs/server-configuration.html#environment-variables).
 

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -34,6 +34,14 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.hostAliases }}
+      hostAliases:
+      {{- range .Values.hostAliases }}
+        - hostnames: {{- range .hostnames }}
+          - {{ . }}{{- end}}
+          ip: {{ .ip }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ template "atlantis.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.mount }}
       securityContext:

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -286,3 +286,12 @@ initContainers: []
 # - name: example
 #   image: alpine:latest
 #   command: ['sh', '-c', 'echo The init container is running! && sleep 10']
+
+# hostAliases:
+#   - hostnames:
+#     - aaa.com
+#     - test.ccc.com
+#     ip: 10.0.0.0
+#   - hostnames:
+#     - bbb.com
+#     ip: 10.0.0.2


### PR DESCRIPTION
It may be required to set custom host aliases within the pods, this allows this functionality via an optional value.

Values example
```
hostAliases:
  - hostnames:
    - aaa.com
    - test.ccc.com
    ip: 10.0.0.0
  - hostnames:
    - bbb.com
    ip: 10.0.0.2
```