### PR TITLE
Allow overriding fsGroup/runAsUser in statefulset if necessary

### DIFF
--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -44,9 +44,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "atlantis.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.mount }}
-      securityContext:
-        fsGroup: 1000
-        runAsUser: 100
+      securityContext: {{ .Values.statefulSet.securityContext | toYaml | nindent 8 }}
       volumes:
       {{- if .Values.tlsSecretName }}
       - name: tls

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -171,6 +171,9 @@ podTemplate:
 statefulSet:
   annotations: {}
   labels: {}
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 100
 
 ingress:
   enabled: true


### PR DESCRIPTION
The requirements of my base container force me to use a different uid, this patch helps me use the upstream chart while still using a custom Atlantis container.