### PR TITLE
feat: optionally allow to customize the terminationGracePeriodSeconds of the Statefull Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following options are supported.  See [values.yaml](/charts/atlantis/values.
 | `podTemplate.labels`                        | Additional labels to use for pods. | `{}` |
 | `statefulSet.annotations`                   | Additional annotations to use for StatefulSet. | `{}` |
 | `statefulSet.labels`                        | Additional labels to use for StatefulSet. | `{}` |
+| `terminationGracePeriodSeconds`             | Set terminationGracePeriodSeconds for the StatefulSet. | `{}` |
 | `logLevel`                                  | Level to use for logging. Either debug, info, warn, or error.                                                                                                                                                                                                                                             | n/a     |
 | `orgWhitelist`                              | Whitelist of repositories from which Atlantis will accept webhooks. **This value must be set for Atlantis to function correctly.** Accepts wildcard characters (`*`). Multiple values may be comma-separated.                                                                                             | none    |
 | `config`                                    | Override atlantis main configuration by config map. It's allow some additional functionality like slack notifications.                                                                                                                                                                                | n/a     |

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.19.2
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.18.0
+version: 3.19.0
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -44,6 +44,9 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "atlantis.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.mount }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       securityContext:
         fsGroup: 1000
         runAsUser: 100

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -172,6 +172,9 @@ statefulSet:
   annotations: {}
   labels: {}
 
+## Optionally customize the terminationGracePeriodSeconds
+# terminationGracePeriodSeconds: 60
+
 ingress:
   enabled: true
   annotations: {}


### PR DESCRIPTION
I would like to customize the terminationGracePeriodSeconds of the Statefull Set. 

Please find that config setting inside this PR.

- Updateded readme
- Updated values.yaml
- Added terminationGracePeriodSeconds as conditional, so that it can fall back to the Kubernetes default

Test:
- Tested it manually, deploying atlantis wits terraform helm_releease inside a GKE cluster. Works fine.

