### PR TITLE
fix: update apiversion for ingress. fixes #75

### DIFF
--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "atlantis.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
This change updates the maximum apiVersion for ingress if the Kubernetes cluster Atlantis is running on supports it.