### PR TITLE
Add Markdown Diff Flag

### DIFF
--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -179,6 +179,10 @@ spec:
           - name: ATLANTIS_DISABLE_REPO_LOCKING
             value: {{ .Values.disableRepoLocking | quote }}
           {{- end }}
+          {{- if .Values.enableDiffMarkdownFormat }}
+          - name: ATLANTIS_ENABLE_DIFF_MARKDOWN_FORMAT
+            value: {{ .Values.enableDiffMarkdownFormat | quote }}
+          {{- end }}
           {{- if .Values.defaultTFVersion }}
           - name: ATLANTIS_DEFAULT_TF_VERSION
             value: {{ .Values.defaultTFVersion }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -139,6 +139,9 @@ disableApplyAll: false
 # disableRepoLocking stops atlantis locking projects and or workspaces when running terraform
 disableRepoLocking: false 
 
+# Use Diff Markdown Format for color coding diffs
+enableDiffMarkdownFormat: false
+
 # We only need to check every 60s since Atlantis is not a high-throughput service.
 livenessProbe:
   enabled: true


### PR DESCRIPTION
Add flag to enable https://github.com/runatlantis/atlantis/pull/1751 so that we can use color comments. Defaulted to false so no change by default.