### PR TITLE
Set default ingress.path to /

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -181,7 +181,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  path:
+  path: /
   pathType: Prefix
   host:
   hosts:


### PR DESCRIPTION
The readme states the default value for this as `/`, and without it, deploying the chart fails.