### PR TITLE
Allow configuring of basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The following options are supported.  See [values.yaml](/charts/atlantis/values.
 | `initContainers`                            | Containers used to initialize context for Atlantis pods                                  | `[]`                              |
 | `extraContainers`                           | Additionnal containers to use and depends of use cases. | `[]` |
 | `hostAliases[].hostnames`                   | Hostnames for host alias entry                                  | n/a                              |
-| `hostAliases[].ip`                          | IP for host alias entry                                  | `n/a                              |
+| `hostAliases[].ip`                          | IP for host alias entry                                  | n/a                               |
 | `basicAuth.username`                        | Username for basic authentication                        | n/a                               |
 | `basicAuth.password`                        | Password for basic authentication                        | n/a                               |
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ The following options are supported.  See [values.yaml](/charts/atlantis/values.
 | `extraContainers`                           | Additionnal containers to use and depends of use cases. | `[]` |
 | `hostAliases[].hostnames`                   | Hostnames for host alias entry                                  | n/a                              |
 | `hostAliases[].ip`                          | IP for host alias entry                                  | `n/a                              |
+| `basicAuth.username`                        | Username for basic authentication                        | n/a                               |
+| `basicAuth.password`                        | Password for basic authentication                        | n/a                               |
 
 **NOTE**: All the [Server Configurations](https://www.runatlantis.io/docs/server-configuration.html) are passed as [Environment Variables](https://www.runatlantis.io/docs/server-configuration.html#environment-variables).
 

--- a/charts/atlantis/templates/_helpers.tpl
+++ b/charts/atlantis/templates/_helpers.tpl
@@ -81,3 +81,14 @@ Generates AWS Secret name
     {{ template "atlantis.fullname" . }}-aws
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generates Basic Auth name
+*/}}
+{{- define "atlantis.basicAuthSecretName" -}}
+{{- if .Values.basicAuthSecretName -}}
+    {{ .Values.basicAuthSecretName }}
+{{- else -}}
+    {{ template "atlantis.fullname" . }}-basic-auth
+{{- end -}}
+{{- end -}}

--- a/charts/atlantis/templates/secret-basic-auth.yaml
+++ b/charts/atlantis/templates/secret-basic-auth.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.basicAuth }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "atlantis.fullname" . }}-basic-auth
+  labels:
+    app: {{ template "atlantis.name" . }}
+    chart: {{ template "atlantis.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  username: {{ .Values.basicAuth.username | b64enc }}
+  password: {{ .Values.basicAuth.password | b64enc }}
+{{- end }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -311,12 +311,31 @@ spec:
                 name: {{ template "atlantis.vcsSecretName" . }}
                 key: azuredevops_webhook_password
           {{- end}}
+          {{- if .Values.basicAuth }}
+          - name: ATLANTIS_WEB_BASIC_AUTH
+            value: "true"
+          - name: ATLANTIS_WEB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "atlantis.basicAuthSecretName" . }}
+                key: username
+          - name: ATLANTIS_WEB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "atlantis.basicAuthSecretName" . }}
+                key: password
+          {{- end}}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: 4141
               scheme: {{ .Values.livenessProbe.scheme }}
+              {{- if .Values.basicAuth }}
+              httpHeaders:
+              - name: Authorization
+                value: "Basic {{ printf "%s:%s" .Values.basicAuth.username .Values.basicAuth.password | b64enc }}"
+              {{- end}}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -329,6 +348,11 @@ spec:
               path: /healthz
               port: 4141
               scheme: {{ .Values.readinessProbe.scheme }}
+              {{- if .Values.basicAuth }}
+              httpHeaders:
+              - name: Authorization
+                value: "Basic {{ printf "%s:%s" .Values.basicAuth.username .Values.basicAuth.password | b64enc }}"
+              {{- end}}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -331,11 +331,6 @@ spec:
               path: /healthz
               port: 4141
               scheme: {{ .Values.livenessProbe.scheme }}
-              {{- if .Values.basicAuth }}
-              httpHeaders:
-              - name: Authorization
-                value: "Basic {{ printf "%s:%s" .Values.basicAuth.username .Values.basicAuth.password | b64enc }}"
-              {{- end}}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -348,11 +343,6 @@ spec:
               path: /healthz
               port: 4141
               scheme: {{ .Values.readinessProbe.scheme }}
-              {{- if .Values.basicAuth }}
-              httpHeaders:
-              - name: Authorization
-                value: "Basic {{ printf "%s:%s" .Values.basicAuth.username .Values.basicAuth.password | b64enc }}"
-              {{- end}}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -152,6 +152,11 @@ disableRepoLocking: false
 # Use Diff Markdown Format for color coding diffs
 enableDiffMarkdownFormat: false
 
+# Optionally specify an username and a password for basic authentication 
+basicAuth:
+  username: "atlantis"
+  password: "atlantis"
+
 # We only need to check every 60s since Atlantis is not a high-throughput service.
 livenessProbe:
   enabled: true


### PR DESCRIPTION
With the [runatlantis/atlantis v0.17.5](https://github.com/runatlantis/atlantis/releases/tag/v0.17.5) release, users are allowed to configure a basic authentication. The helm chart does not allow the `livenessProbe` and `readinessProbe` to add custom headers, so this PR adds support for both the creation of credentials and probes.

In this PR you will find:
* Updated values
* Updated README
* A secret resource holding credentials
* Modified StatefulSet resource to inject the environments required by the basic authentication configuration (`ATLANTIS_WEB_BASIC_AUTH`, `ATLANTIS_WEB_USERNAME`, `ATLANTIS_WEB_PASSWORD`)
* [Removed] Modified `livenessProbe` and `readinessProbe` to add a basic authorization header

Tested it manually, deploying atlantis in an EKS cluster.

Edit:
There's no need for `livenessProbe` and `readinessProbe` to add a basic authorization header since the bug was fixed in atlantis source code [#1896](https://github.com/runatlantis/atlantis/pull/1896), so the code was removed.