### PR TITLE
fix: avoid '"/key.pem": must be a relative path'

### DIFF
--- a/charts/atlantis/templates/secret-webhook.yaml
+++ b/charts/atlantis/templates/secret-webhook.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   {{- if .Values.githubApp }}
-  key.pem: {{ required "githubApp.key.pem is required if githubApp configuration is specified." (index .Values.githubApp "key.pem") | b64enc }}
+  key.pem: {{ required "githubApp.key is required if githubApp configuration is specified." .Values.githubApp.key | b64enc }}
   github_secret: {{ required "githubApp.secret is required if githubApp configuration is specified." .Values.githubApp.secret | b64enc }}
   {{- end}}
   {{- if .Values.github }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
           secretName: {{ template "atlantis.awsSecretName" . }}
       {{- end }}
       {{- if .Values.githubApp }}
-      {{- if index .Values.githubApp "key.pem"}}
+      {{- if .Values.githubApp.key }}
       - name: github-app-key-volume
         secret:
           secretName: {{ template "atlantis.vcsSecretName" . }}
@@ -254,7 +254,7 @@ spec:
                 name: {{ template "atlantis.vcsSecretName" . }}
                 key: github_secret
           {{- end }}
-          {{- if index .Values.githubApp "key.pem" }}
+          {{- if .Values.githubApp.key }}
           - name: ATLANTIS_GH_APP_KEY_FILE
             value: "/var/github-app/key.pem"
           {{- end }}
@@ -383,7 +383,7 @@ spec:
             readOnly: true
           {{- end }}
           {{- if .Values.githubApp }}
-          {{- if index .Values.githubApp "key.pem" }}
+          {{- if .Values.githubApp.key }}
           - name: github-app-key-volume
             mountPath: /var/github-app
             readOnly: true

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
           secretName: {{ template "atlantis.vcsSecretName" . }}
           items:
           - key: key.pem
-            path: /key.pem
+            path: key.pem
       {{- end }}
       {{- end }}
       {{- if .Values.repoConfig }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -247,7 +247,7 @@ spec:
           {{- end }}
           - name: ATLANTIS_WRITE_GIT_CREDS
             value: "true"
-          {{- if .Values.githubApp.github_secret }}
+          {{- if .Values.githubApp.secret }}
           - name: ATLANTIS_GH_WEBHOOK_SECRET
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
the existing githubApp logic results in 
```shell
  Warning  FailedCreate      5m6s (x18 over 16m)  statefulset-controller  create Pod atlantis-0 in StatefulSet atlantis failed error: Pod "atlantis-0" is invalid: [spec.volumes[1].secret.items[0].path: Invalid value: "/key.pem": must be a relative path, spec.containers[0].volumeMounts[1].name: Not found: "github-app-key-volume"]
```
also
`{{- if index .Values.githubApp "key.pem"}}` is kind of messy with indexing values and the helm conventions strongly suggest 

> Variable names should begin with a lowercase letter, and words should be separated with camelcase