### PR TITLE
fix: disable basic auth by default

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -153,9 +153,9 @@ disableRepoLocking: false
 enableDiffMarkdownFormat: false
 
 # Optionally specify an username and a password for basic authentication
-basicAuth:
-  username: "atlantis"
-  password: "atlantis"
+# basicAuth:
+#   username: "atlantis"
+#   password: "atlantis"
 
 # We only need to check every 60s since Atlantis is not a high-throughput service.
 livenessProbe:


### PR DESCRIPTION
Having the default basicAuth block uncommented under values as
introduced in #98 causes this chart to be backwards incompatible with
existing installations.