### PR TITLE
fix: use github app config from external secret

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.19.2
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.17.0
+version: 3.17.1
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -383,7 +383,7 @@ spec:
             readOnly: true
           {{- end }}
           {{- if .Values.githubApp }}
-          {{- if .Values.githubApp.key }}
+          {{- if or .Values.githubApp.key .Values.vcsSecretName}}
           - name: github-app-key-volume
             mountPath: /var/github-app
             readOnly: true

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
           secretName: {{ template "atlantis.awsSecretName" . }}
       {{- end }}
       {{- if .Values.githubApp }}
-      {{- if .Values.githubApp.key }}
+      {{- if or .Values.githubApp.key .Values.vcsSecretName}}
       - name: github-app-key-volume
         secret:
           secretName: {{ template "atlantis.vcsSecretName" . }}
@@ -247,14 +247,14 @@ spec:
           {{- end }}
           - name: ATLANTIS_WRITE_GIT_CREDS
             value: "true"
-          {{- if .Values.githubApp.secret }}
+          {{- if or .Values.githubApp.secret .Values.vcsSecretName}}
           - name: ATLANTIS_GH_WEBHOOK_SECRET
             valueFrom:
               secretKeyRef:
                 name: {{ template "atlantis.vcsSecretName" . }}
                 key: github_secret
           {{- end }}
-          {{- if .Values.githubApp.key }}
+          {{- if or .Values.githubApp.key .Values.vcsSecretName}}
           - name: ATLANTIS_GH_APP_KEY_FILE
             value: "/var/github-app/key.pem"
           {{- end }}


### PR DESCRIPTION
Only setting `vcsSecretName` was not enough to get Github App working, since some **StatefulSet** configuration are valid only if `githubApp.key or githubApp.secret`  have values.

for now I'm using something like this

```yaml
  githubApp:
    id: 123456
    key: fake
    secret: fake

  vcsSecretName: "github-secrets"
```

`github-secrets` is a secret created outside the chart and setting dummy values for key and secret works just fine but I'm not sure if this is intended. 