### PR TITLE
Modify ingress template to choose the proper group/version for clusters <=1.18.

### DIFF
--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -2,9 +2,9 @@
 {{- $fullName := include "atlantis.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $pathType := .Values.ingress.pathType -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta" -}}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -39,18 +39,18 @@ spec:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
-            {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ .Values.service.port }}
             pathType: {{ .Values.ingress.pathType }}
-            {{- else -}}
+            {{ else }}
               serviceName: {{ $fullName }}
               servicePort: {{ .Values.service.port }}
             {{- end }}
     {{ else }}
-    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:


### PR DESCRIPTION
When deploying to a cluster version 1.18 this chart incorrectly tries to use `networking.k8s.io/v1`. This seems to be due to the `networking.k8s.io` existing for some resource kinds, but not for `Ingress`. For example [NetworkPolicy](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).

The solution is to check for `networking.k8s.io/v1/Ingress` or `networking.k8s.io/v1beta/Ingress`. 

There was also an issue with line 48. When the chart was able to choose the correct version the formatting was wrong. 

Tested this change using kind on k8s versions 1.18 through 1.23. 

Fixes https://github.com/runatlantis/helm-charts/issues/96

Here is a similar issue on another project for reference: https://gitea.com/gitea/helm-chart/issues/77

I realize v1.18 is really old, but some of us have old clusters and this change does not break newer versions. 