### PR TITLE
update default atlantis to 0.18.5

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v0.18.4
+appVersion: v0.18.5
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.15.4
+version: 3.15.5
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -100,7 +100,7 @@ serviceAccountSecrets:
 
 image:
   repository: runatlantis/atlantis
-  tag: v0.18.4
+  tag: v0.18.5
   pullPolicy: IfNotPresent
 
 ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
Emergency update due to a bug found with 0.18.4 (https://github.com/runatlantis/atlantis/issues/2104)

relates to https://github.com/runatlantis/atlantis/pull/2107

