### PR TITLE
fix: use ghcr instead of dockerhub

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.18.5
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 3.15.5
+version: 3.15.6
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -99,7 +99,7 @@ serviceAccountSecrets:
 ## -------------------------- ##
 
 image:
-  repository: runatlantis/atlantis
+  repository: ghcr.io/runatlantis/atlantis
   tag: v0.18.5
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
it _seems_ as though starting from atlantis 0.18.5 dockerhub support has been dropped. 

this uses ghcr instead

https://github.com/runatlantis/atlantis/releases/tag/v0.18.5

---

fixes https://github.com/runatlantis/atlantis/issues/2110
relates to https://github.com/runatlantis/atlantis/pull/2107