### PR TITLE
Fixed extraContainers struct in values.yaml

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -347,7 +347,7 @@ extraArgs: []
 # - --disable-repo-locking
 
 extraContainers: []
-# containers:
+# extraContainers:
 #  - name: <container name>
 #    args:
 #      - ...


### PR DESCRIPTION
If I understand it correctly here "containers" should be "extraContainers", to be in line with the declaration above.