### PR TITLE
Fix slow startup by doing chmod once

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -197,6 +197,7 @@ statefulSet:
   securityContext:
     fsGroup: 1000
     runAsUser: 100
+    fsGroupChangePolicy: "OnRootMismatch"
 
 ## Optionally customize the terminationGracePeriodSeconds
 # terminationGracePeriodSeconds: 60


### PR DESCRIPTION
Use `fsGroupChangePolicy: "OnRootMismatch"` (stable in k8s 1.23) to eliminate unnecessary chmod that can be slow for large volumes.

See https://github.com/runatlantis/helm-charts/issues/14

See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods