### PR TITLE
Adding ability to set API Secret to enable API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ The following options are supported.  See [values.yaml](/charts/atlantis/values.
 | `containerSecurityContext.allowPrivilegeEscalation` | Whether to enable privilege escalation           | n/a                               |
 | `containerSecurityContext.readOnlyRootFilesystem`   | Whether the root file system should be read-only | n/a                               |
 | `customPem`   | SecretName of the custom `ca-certificates.cert` to override the `/etc/ssl/certs/ca-certificates.crt` with your custom one (self-signed certificates)<br>Secret has to be created manually and shal contain `ca-certificates.crt: PEM` | n/a                               |
-| `api.secret`                                | API secret to enable API endpoints                       | n/a        |
+| `api.secret`    | API secret to enable API endpoints                                                                        | n/a        |
+| `apiSecretName` | Name of a pre-existing Kubernetes `Secret` containing a `apisecret` key. Use this instead of `api.secret` | n/a        |
 
 **NOTE**: All the [Server Configurations](https://www.runatlantis.io/docs/server-configuration.html) are passed as [Environment Variables](https://www.runatlantis.io/docs/server-configuration.html#environment-variables).
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The following options are supported.  See [values.yaml](/charts/atlantis/values.
 | `containerSecurityContext.allowPrivilegeEscalation` | Whether to enable privilege escalation           | n/a                               |
 | `containerSecurityContext.readOnlyRootFilesystem`   | Whether the root file system should be read-only | n/a                               |
 | `customPem`   | SecretName of the custom `ca-certificates.cert` to override the `/etc/ssl/certs/ca-certificates.crt` with your custom one (self-signed certificates)<br>Secret has to be created manually and shal contain `ca-certificates.crt: PEM` | n/a                               |
+| `api.secret`                                | API secret to enable API endpoints                       | n/a        |
 
 **NOTE**: All the [Server Configurations](https://www.runatlantis.io/docs/server-configuration.html) are passed as [Environment Variables](https://www.runatlantis.io/docs/server-configuration.html#environment-variables).
 

--- a/charts/atlantis/templates/_helpers.tpl
+++ b/charts/atlantis/templates/_helpers.tpl
@@ -94,6 +94,17 @@ Generates Basic Auth name
 {{- end -}}
 
 {{/*
+Generates API Secret name
+*/}}
+{{- define "atlantis.apiSecretName" -}}
+{{- if .Values.apiSecretName -}}
+    {{ .Values.apiSecretName }}
+{{- else -}}
+    {{ template "atlantis.fullname" . }}-api
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "atlantis.labels" -}}

--- a/charts/atlantis/templates/secret-api.yaml
+++ b/charts/atlantis/templates/secret-api.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
 {{- include "atlantis.labels" . | nindent 4 }}
 data:
-  api_secret: {{ .Values.api.secret | b64enc }}
+  apisecret: {{ .Values.api.secret | b64enc }}
 {{- end }}

--- a/charts/atlantis/templates/secret-api.yaml
+++ b/charts/atlantis/templates/secret-api.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.api }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "atlantis.apiSecretName" . }}
+  labels:
+{{- include "atlantis.labels" . | nindent 4 }}
+data:
+  api_secret: {{ .Values.api.secret | b64enc }}
+{{- end }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -348,6 +348,13 @@ spec:
                 name: {{ template "atlantis.basicAuthSecretName" . }}
                 key: password
           {{- end}}
+          {{- if .Values.api }}
+          - name: ATLANTIS_API_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "atlantis.apiSecretName" . }}
+                key: api_secret
+          {{- end}}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -348,12 +348,12 @@ spec:
                 name: {{ template "atlantis.basicAuthSecretName" . }}
                 key: password
           {{- end}}
-          {{- if .Values.api }}
+          {{- if or .Values.api .Values.apiSecretName }}
           - name: ATLANTIS_API_SECRET
             valueFrom:
               secretKeyRef:
                 name: {{ template "atlantis.apiSecretName" . }}
-                key: api_secret
+                key: apisecret
           {{- end}}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -161,6 +161,9 @@ enableDiffMarkdownFormat: false
 # api:
 #   secret: "s3cr3t"
 
+# If managing secrets outside the chart for the API secret, use this variable to reference the secret name
+# apiSecretName: "myapisecret"
+
 # Common Labels for all resources created by this chart.
 commonLabels: {}
 

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -157,6 +157,10 @@ enableDiffMarkdownFormat: false
 #   username: "atlantis"
 #   password: "atlantis"
 
+# Optionally specify an API secret to enable the API
+# api:
+#   secret: "s3cr3t"
+
 # Common Labels for all resources created by this chart.
 commonLabels: {}
 


### PR DESCRIPTION
With [v0.19.8](https://github.com/runatlantis/atlantis/releases/tag/v0.19.8), there is now a programmatic API available for Atlantis. This PR adds the ability to enable the API.