### PR TITLE
Add /* as a default ingress path

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -216,7 +216,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  path: /
+  path: /*
 ## this is in case we want several paths under the same host, with different backend services
 #  paths:
 #    - path: "/path1"

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -225,7 +225,7 @@ ingress:
 #    - path: "/path2"
 #      service: test2
 #      port:
-  pathType: Prefix
+  pathType: ImplementationSpecific
   host:
 
 ## in case we need several hosts:


### PR DESCRIPTION
## what
- Add /* as a default ingress path

## why
- This will allow access to / and other common atlantis api paths

## references
- closes https://github.com/runatlantis/helm-charts/issues/166