### PR TITLE
removing namespaceSelector in PodMonitor

### DIFF
--- a/charts/atlantis/templates/podmonitor.yaml
+++ b/charts/atlantis/templates/podmonitor.yaml
@@ -12,10 +12,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-{{- include "atlantis.labels" . | nindent 4 }}
-  namespaceSelector:
-    matchNames:
-     - {{ .Release.Namespace }}
+{{- include "atlantis.labels" . | nindent 6 }}
   endpoints:
   - port: atlantis
     interval: {{ .Values.podMonitor.interval }}


### PR DESCRIPTION
Description:
namespaceSelector is not supported in PodMonitor `spec.selector` and set nindent 6 instead of 4
Ref: https://github.com/GoogleCloudPlatform/prometheus-engine/blob/v0.4.3-gke.0/doc/api.md#podmonitoringspec

Error message:
```
Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(PodMonitoring.spec): unknown field "namespaceSelector" in com.googleapis.monitoring.v1.PodMonitoring.spec, ValidationError(PodMonitoring.spec.selector): unknown field "app" in com.googleapis.monitoring.v1.PodMonitoring.spec.selector
```