### PR TITLE
fix: service monitor spacing

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.19.8
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.0.9
+version: 4.0.10
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/servicemonitor.yaml
+++ b/charts/atlantis/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-{{- include "atlantis.labels" . | nindent 4 }}
+{{- include "atlantis.labels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
      - {{ .Release.Namespace }}


### PR DESCRIPTION
- fixing ident on template for serviceMonitor

Seeing error when trying to apply

```
Error: error validating "": error validating data: [ValidationError(ServiceMonitor.spec.selector): unknown field "app" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field "chart" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field "heritage" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field "release" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector]
```