### PR TITLE
fix orgWhitelist fallback #154

### DIFF
--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -227,7 +227,7 @@ spec:
           - name: ATLANTIS_DATA_DIR
             value: /atlantis-data
           - name: ATLANTIS_REPO_ALLOWLIST
-            value: {{ toYaml (coalesce .Values.orgAllowlist .Values.orgWhitelist) }}
+            value: {{ toYaml (coalesce .Values.orgWhitelist .Values.orgAllowlist) }}
           - name: ATLANTIS_PORT
             value: "4141"
           {{- if .Values.repoConfig }}


### PR DESCRIPTION
coalesce isn't properly fallbacking `orgAllowlist` to `orgWhitelist` because there is a default value for `orgAllowlist` (*\<replace-me>*)