### PR TITLE
fix matchLabels in PodMonitor selector

### DIFF
--- a/charts/atlantis/templates/podmonitor.yaml
+++ b/charts/atlantis/templates/podmonitor.yaml
@@ -12,7 +12,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-{{- include "atlantis.labels" . | nindent 6 }}
+      app: {{ template "atlantis.name" . }}
+      release: {{ .Release.Name }}
+{{- if .Values.podTemplate.labels }}
+{{ toYaml .Values.podTemplate.labels | indent 6 }}
+{{- end }}
   endpoints:
   - port: atlantis
     interval: {{ .Values.podMonitor.interval }}


### PR DESCRIPTION
with the current `matchLabels` set in PodMonitor `selector`.
Google Managed Prometheus won't add it into metrics collector because it is difference with [atlantis container's labels](https://github.com/runatlantis/helm-charts/blob/main/charts/atlantis/templates/statefulset.yaml#L23).

