### PR TITLE
add enabling prometheus metrics step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ repoConfig: |
   * `atlantis_data_storageClass` => `storageClassName` **NOTE: more than just a snake_case change**
   * `bitbucket.base_url` => `bitbucket.baseURL`
 
+## Enabling Prometheus Metrics
+* The following config set in `repoConfig:` helps enabling atlantis's metrics endpoint for Prometheus scraping. These metrics can be used for self hosted Prometheus or Google Managed Prometheus.
+```yaml
+repoConfig: |
+  ---
+  metrics:
+    prometheus:
+      endpoint: /metrics
+```
+
 ## Testing the Deployment
 To perform a smoke test of the deployment (i.e. ensure that the Atlantis UI is up and running):
 


### PR DESCRIPTION
I had a bit of hard time to learn how to enable prometheus metrics in atlantis.
So hopefully by adding the instruction in README.md. It will help others.

Looks like enabling prometheus metrics is not updated in Atlantis docs or I could not find it.
https://www.runatlantis.io/docs/configuring-atlantis.html