### PR TITLE
Make container resources optional

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.19.8
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.1.0
+version: 4.1.1
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -441,8 +441,10 @@ spec:
           {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 10 }}
           {{- end }}
+          {{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- end }}
       {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -246,13 +246,14 @@ ingress:
 # You have to create a secret `my-ca-certificates`
 # customPem: my-ca-certificates
 
-resources:
-  requests:
-    memory: 1Gi
-    cpu: 100m
-  limits:
-    memory: 1Gi
-    cpu: 100m
+resources: {}
+# resources:
+#   requests:
+#     memory: 1Gi
+#     cpu: 100m
+#   limits:
+#     memory: 1Gi
+#     cpu: 100m
 
 ## Embedded data volume & volumeMount (default working)
 volumeClaim:


### PR DESCRIPTION
We are seeing CPU throttling with atlantis because of the CPU limits. 
It would be nice to make the resources (requests & limits) optional, so they can be configured per use case