### PR TITLE
Add mergeable-bypass-apply flag

### DIFF
--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -245,6 +245,10 @@ spec:
             value: http://{{ .Values.ingress.host }}
             {{- end }}
           {{- end }}
+          {{- if .Values.mergeableBypassApply }}
+          - name: ATLANTIS_GH_MERGEABLE_BYPASS_APPLY
+            value: {{ .Values.mergeableBypassApply | quote }}
+          {{- end }}             
           {{- if .Values.github }}
           - name: ATLANTIS_GH_USER
             value: {{ required "github.user is required if github configuration is specified." .Values.github.user }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -152,6 +152,9 @@ disableRepoLocking: false
 # Use Diff Markdown Format for color coding diffs
 enableDiffMarkdownFormat: false
 
+# mergeableBypassApply allows the mergeable check to skip checking the status of `atlantis/apply`
+mergeableBypassApply: true
+
 # Optionally specify an username and a password for basic authentication
 # basicAuth:
 #   username: "atlantis"


### PR DESCRIPTION
Hello!

This PR adds the `ATLANTIS_GH_MERGEABLE_BYPASS_APPLY` envVar in order to be able to use the mergeable mode with required apply status check when deploying atlantis with the chart.