### PR TITLE
Add GitHub Org Support

### DIFF
--- a/charts/atlantis/templates/secret-webhook.yaml
+++ b/charts/atlantis/templates/secret-webhook.yaml
@@ -13,6 +13,9 @@ data:
   {{- if .Values.github }}
   github_token: {{ required "github.token is required if github configuration is specified." .Values.github.token | b64enc }}
   github_secret: {{ required "github.secret is required if github configuration is specified." .Values.github.secret | b64enc }}
+  {{- if .Values.github.org }}
+  github_org: {{ .Values.github.org | b64enc }}
+  {{- end}}
   {{- end}}
   {{- if .Values.gitlab }}
   gitlab_token: {{ required "gitlab.token is required if gitlab configuration is specified." .Values.gitlab.token | b64enc }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -258,6 +258,10 @@ spec:
               secretKeyRef:
                 name: {{ template "atlantis.vcsSecretName" . }}
                 key: github_secret
+          {{- if .Values.github.org }}
+          - name: ATLANTIS_GH_ORG
+            value: {{ .Values.github.org }}
+          {{- end }}
           {{- if .Values.github.hostname }}
           - name: ATLANTIS_GH_HOSTNAME
             value: {{ .Values.github.hostname }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -15,6 +15,7 @@ orgAllowlist: <replace-me>
 #   user: foo
 #   token: bar
 #   secret: baz
+#   org: your-org (optional)
 # GitHub Enterprise only:
 #   hostname: github.your.org
 # (The chart will perform the base64 encoding for you for values that are stored in secrets.)


### PR DESCRIPTION
This allows the chart support installing against a GitHub org (not related to GitHub Enterprise).