### PR TITLE
Remove default `orgAllowlist` value

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -6,8 +6,8 @@
 ##   if not using an ingress, set it to the external IP.
 # atlantisUrl: http://10.0.0.0
 
-# Replace this with your own repo allowlist:
-orgAllowlist: <replace-me>
+# Set a repo allowlist using orgAllowlist. The previous key orgWhitelist is deprecated but still valid.
+# orgAllowlist: <replace-me>
 # logLevel: "debug"
 
 # If using GitHub, specify like the following:


### PR DESCRIPTION
## what
- Remove default allowlist value

## why
- There is a coalesce statement that will use the `orgAllowlist` instead of the deprecated `orgWhitelist`. However, since the default value of `orgWhitelist` used to be `<replace-me>` and since it was renamed, the `coalesce()` statement would resolve to `<replace-me>` which was destructive to anyone upgrading who had no switched to the non-deprecated value name.

https://github.com/runatlantis/helm-charts/blob/89da1af324c27bbe608052a577d60957a030e9b4/charts/atlantis/templates/statefulset.yaml#L221-L222

- By removing the default value for `orgAllowlist`, the `coalesce()` statement should check `orgAllowlist` and if it is empty, it should use `orgWhitelist`. If both are null, helm should fail.

## references
- Attempts to close https://github.com/runatlantis/helm-charts/issues/154