### PR TITLE
Allow optional host to be set

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.20.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.1.2
+version: 4.1.3
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -32,8 +32,11 @@ spec:
 {{ toYaml .Values.ingress.tls | indent 4 }}
 {{- end }}
   rules:
-    {{- if .Values.ingress.host }}
-    - host: {{ .Values.ingress.host }}
+    {{- if not .Values.ingress.hosts }}
+    -
+      {{- if .Values.ingress.host }}
+      host: {{ .Values.ingress.host }}
+      {{- end }}
       http:
         paths:
         {{- if .Values.ingress.paths }}
@@ -68,7 +71,10 @@ spec:
     {{ else }}
     {{- if eq $apiVersion "networking.k8s.io/v1" -}}
     {{- range $k := .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    -
+      {{- if .host }}
+      host: {{ .host }}
+      {{- end }}
       http:
         paths:
         {{- range .paths }}
@@ -87,7 +93,10 @@ spec:
     {{- end }}
     {{- else -}}
     {{- range $k := .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    -
+      {{- if .host }}
+      host: {{ .host }}
+      {{- end }}
       http:
         paths:
         {{- range .paths }}

--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -69,7 +69,6 @@ spec:
             {{- end }}
         {{- end }}
     {{ else }}
-    {{- if eq $apiVersion "networking.k8s.io/v1" -}}
     {{- range $k := .Values.ingress.hosts }}
     -
       {{- if .host }}
@@ -80,36 +79,25 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
+              {{- if eq $apiVersion "networking.k8s.io/v1" -}}
               service:
-              {{- if $k.service }}
+                {{- if $k.service }}
                 name: {{ $k.service }}
-              {{- else }}
+                {{- else }}
                 name: {{ $fullName }}
-              {{- end }}
+                {{- end }}
                 port:
                   number: {{ $svcPort }}
+              {{- else -}}
+                {{- if $k.service }}
+              serviceName: {{ $k.service }}
+                {{- else }}
+              serviceName: {{ $fullName }}
+                {{- end }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
             pathType: {{ $pathType }}
         {{- end }}
-    {{- end }}
-    {{- else -}}
-    {{- range $k := .Values.ingress.hosts }}
-    -
-      {{- if .host }}
-      host: {{ .host | quote }}
-      {{- end }}
-      http:
-        paths:
-        {{- range .paths }}
-          - path: {{ . }}
-            backend:
-            {{- if $k.service }}
-              serviceName: {{ $k.service }}
-            {{- else }}
-              serviceName: {{ $fullName }}
-            {{- end }}
-              servicePort: {{ $svcPort }}
-        {{- end }}
-    {{- end }}
     {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
     {{- if not .Values.ingress.hosts }}
     -
       {{- if .Values.ingress.host }}
-      host: {{ .Values.ingress.host }}
+      host: {{ .Values.ingress.host | quote }}
       {{- end }}
       http:
         paths:
@@ -73,7 +73,7 @@ spec:
     {{- range $k := .Values.ingress.hosts }}
     -
       {{- if .host }}
-      host: {{ .host }}
+      host: {{ .host | quote }}
       {{- end }}
       http:
         paths:
@@ -95,7 +95,7 @@ spec:
     {{- range $k := .Values.ingress.hosts }}
     -
       {{- if .host }}
-      host: {{ .host }}
+      host: {{ .host | quote }}
       {{- end }}
       http:
         paths:

--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -80,7 +80,6 @@ spec:
           - path: {{ . }}
             backend:
               {{- if eq $apiVersion "networking.k8s.io/v1" -}}
-              pathType: {{ $pathType }}
               service:
                 {{- if $k.service }}
                 name: {{ $k.service }}
@@ -89,6 +88,7 @@ spec:
                 {{- end }}
                 port:
                   number: {{ $svcPort }}
+            pathType: {{ $pathType }}
               {{- else -}}
                 {{- if $k.service }}
               serviceName: {{ $k.service }}

--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -80,6 +80,7 @@ spec:
           - path: {{ . }}
             backend:
               {{- if eq $apiVersion "networking.k8s.io/v1" -}}
+              pathType: {{ $pathType }}
               service:
                 {{- if $k.service }}
                 name: {{ $k.service }}
@@ -96,7 +97,6 @@ spec:
                 {{- end }}
               servicePort: {{ $svcPort }}
               {{- end }}
-            pathType: {{ $pathType }}
         {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -230,12 +230,12 @@ ingress:
 
 ## in case we need several hosts:
   hosts:
-    - host: chart-example.local
-      paths: ["/"]
-#      service: chart-example1
-    - host: chart-example.local2
-#      service: chart-example1
-      paths: ["/lala"]
+  #   - host: chart-example.local
+  #     paths: ["/"]
+  #     service: chart-example1
+  #   - host: chart-example.local2
+  #     service: chart-example1
+  #     paths: ["/lala"]
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
## what
- Allow optional host to be set
- Fix linting issue

## why
> An optional host. In this example, no host is specified, so the rule applies to all inbound HTTP traffic through the IP address specified. If a host is provided (for example, foo.bar.com), the rules apply to that host.

https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules

## references
- Closes https://github.com/runatlantis/helm-charts/issues/201
- https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules

## testing

This command used to return just `rules` but now it will return the paths without the `host` if the `host` is omitted.

```sh
helm template . -s templates/ingress.yaml \
  --set "ingress.host=" \
  --set "ingress.hosts=null" | yq .spec
```

Before this change

```yaml
rules:
```

After this proposed change

```yaml
rules:
  - http:
      paths:
        - path: /*
          backend:
            serviceName: release-name-atlantis
            servicePort: 80
```

This command returns the same result before and after this change. Only difference is that this change will put the `host` in quotes which keeps it consistent with the multiple `hosts` quoting.

```sh
helm template . -s templates/ingress.yaml \
  --set "ingress.host=example.com" \
  --set "ingress.hosts=null" | yq .spec
```

```yaml
rules:
  - host: "example.com"
    http:
      paths:
        - path: /*
          backend:
            serviceName: release-name-atlantis
            servicePort: 80
```