### PR TITLE
fix: #216 fix ingress manifest template

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.20.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.2.1
+version: 4.2.2
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -79,7 +79,7 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              {{- if eq $apiVersion "networking.k8s.io/v1" -}}
+              {{- if eq $apiVersion "networking.k8s.io/v1" }}
               service:
                 {{- if $k.service }}
                 name: {{ $k.service }}


### PR DESCRIPTION
When setting ingress.apiVersion to networking.k8s.io/v1 and  ingress.hosts , the rendered ingress manifest is broken