### PR TITLE
shareProcessNamespace hot patch

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.20.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.5.0
+version: 4.5.1
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       {{- end }}
       serviceAccountName: {{ template "atlantis.serviceAccountName" . }}
-      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.statefulSet.shareProcessNamespace }}
       automountServiceAccountToken: {{ .Values.serviceAccount.mount }}
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}


### PR DESCRIPTION
Hot fix from 
https://github.com/runatlantis/helm-charts/pull/209
the value from`shareProcessNamespace` was pulling from the wrong location. This is a hot patch for it. 
