### PR TITLE
Require GitHub configuration only if bot user is used

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.21.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.8.1
+version: 4.8.2
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/secret-webhook.yaml
+++ b/charts/atlantis/templates/secret-webhook.yaml
@@ -10,7 +10,7 @@ data:
   key.pem: {{ required "githubApp.key is required if githubApp configuration is specified." .Values.githubApp.key | b64enc }}
   github_secret: {{ required "githubApp.secret is required if githubApp configuration is specified." .Values.githubApp.secret | b64enc }}
   {{- end}}
-  {{- if .Values.github }}
+  {{- if .Values.github.user }}
   github_token: {{ required "github.token is required if github configuration is specified." .Values.github.token | b64enc }}
   github_secret: {{ required "github.secret is required if github configuration is specified." .Values.github.secret | b64enc }}
   {{- end}}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -252,7 +252,7 @@ spec:
             value: http://{{ .Values.ingress.host }}
             {{- end }}
           {{- end }}
-          {{- if .Values.github }}
+          {{- if .Values.github.user }}
           - name: ATLANTIS_GH_USER
             value: {{ required "github.user is required if github configuration is specified." .Values.github.user }}
           - name: ATLANTIS_GH_TOKEN


### PR DESCRIPTION
When using GitHub Enterprise, `github.hostname` has to be set. If Atlantis uses a GitHub App for it's setup, the `github.user`, `github.token`,`github.secret` values are not needed, and it causes issues and conflicts when it's set.

To avoid this, the `github.user` value should be checked instead of just `github`, since the other two values are required for that setup.

Because `github.user` is already a required field, this should keep the chart backwards compatible, and it shouldn't be a breaking change, but it should let future chart versions use GitHub Enterprise with a GitHub App.