### PR TITLE
Fix github default value missing

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.21.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.9.1
+version: 4.9.2
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -11,6 +11,7 @@ orgAllowlist: <replace-me>
 # logLevel: "debug"
 
 # If using GitHub, specify like the following:
+github: {}
 # github:
 #   user: foo
 #   token: bar


### PR DESCRIPTION
## what
Fix github default value missing

## why
It fixes #236 

## tests
n/a

## references
- closes #236
- closes https://github.com/runatlantis/helm-charts/pull/235

