### PR TITLE
chore(workflows): define setup-helm action patch version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.10 # renovate: datasource=github-releases depName=helm packageName=helm/helm
+          version: v3.10.3 # renovate: datasource=github-releases depName=helm packageName=helm/helm
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1


### PR DESCRIPTION
## what
Bump helm to the latest version

## why
The pipeline is failing, because `3.10` is not a valid version number. It should be `3.10.0` or `3.10.3`, which is the latest.

## references
[Failed run](https://github.com/runatlantis/helm-charts/actions/runs/3859256677/jobs/6578609819)
[Helm 3.10.0](https://github.com/helm/helm/releases/tag/v3.10.0)
[Helm 3.10.3](https://github.com/helm/helm/releases/tag/v3.10.3)

