### PR TITLE
chore(ci): bump chart-releaser action to v1.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,6 @@ jobs:
           version: v3.10.3 # renovate: datasource=github-releases depName=helm packageName=helm/helm
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1
+        uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## what
- Chart-releaser seems to be failing to update the index.yaml in the gh-pages branch. 

## why
Hoping a combination of bumping the action and also manually bringing the index.yaml update up to date will help.

## tests
<!--
- [ ] I have tested my changes by ...
-->
## references

https://github.com/runatlantis/helm-charts/pull/253
https://github.com/runatlantis/helm-charts/actions/runs/3969254151/attempts/1

