### PR TITLE
fix: set pullPolicy to `Always` with `latest` tag

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.23.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.11.0
+version: 4.11.1
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -114,7 +114,7 @@ image:
   repository: ghcr.io/runatlantis/atlantis
   # if not set appVersion field from Chart.yaml is used
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 ## Optionally specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- set pullPolicy to `Always` with `latest` tag

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- since we're using latest to avoid having to update this repo for each new version of atlantis, we also need to bump the pull policy so it pulls the latest image when a new one is uploaded
- consistency with runatlantis/atlantis kustomize
- consistency with terraform aws modules atlantis

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- Previous pr #265 
- appVersion is optional https://helm.sh/docs/topics/charts/#the-chartyaml-file
- [latest usage in terraform-aws-atlantis module](https://github.com/terraform-aws-modules/terraform-aws-atlantis/blob/9d4e8ebb668a4b0637bcc0f6a1a2364229275c19/variables.tf#LL552C17-L552C23)
- feedback from @dschunack https://github.com/runatlantis/helm-charts/pull/265#discussion_r1122816742
