### PR TITLE
fix: Use app version instead of latest

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 # renovate datasource=docker depName=ghcr.io/runatlantis/atlantis
-appVersion: v0.23.2
+appVersion: v0.23.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
 version: 4.11.2

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v0.23.0
+appVersion: v0.23.2
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.11.1
+version: 4.11.2
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -113,7 +113,7 @@ serviceAccountSecrets:
 image:
   repository: ghcr.io/runatlantis/atlantis
   # if not set appVersion field from Chart.yaml is used
-  tag: latest
+  tag: ""
   pullPolicy: Always
 
 ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- fix: Use app version instead of latest
- bump to 0.23.2

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- revert back to using app Version instead of latest. While it's easier for maintenance for us to use latest, it's not considered best practices.

## tests

- This is the previous logic.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- previous pr #265 
- previous pr #266 
- https://github.com/runatlantis/atlantis/releases

