### PR TITLE
fix(tolerations): resolve placement errors

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.23.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.12.0
+version: 4.12.1
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -511,10 +511,10 @@ spec:
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
-{{- if .Values.topologySpreadConstraints }}
-      topologySpreadConstraints:
-{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
 {{ toYaml . | indent 8 }}
     {{- end }}
   {{- with .Values.statefulSet.updateStrategy }}


### PR DESCRIPTION
## what

- Fix helm chart issues, `topologySpreadConstraints` is inside `tolerations` block
- Use standardized convention 

## why

- Helm template is giving errors if there's values in `tolerations`

## tests

- [x] I have tested my changes by running `helm template`

## references
- previous pr #264 
