### PR TITLE
fix: update app version link for 0.23.3 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,3 +30,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.23.3
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.12.1
+version: 4.12.2
 keywords:
 - terraform
 home: https://www.runatlantis.io


### PR DESCRIPTION
## what

Fix chart pointing to the wrong atlantis version


## why

broken link


