### PR TITLE
conf: default ingress api version

### DIFF
--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $apiVersion := "extensions/v1beta1" -}}
+{{- $apiVersion := "networking.k8s.io/v1" -}}
 {{- if .Values.ingress.apiVersion -}}
 {{- $apiVersion = .Values.ingress.apiVersion -}}
 {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}


### PR DESCRIPTION
## what

Changing the default api version of ingress in case helm cannot determine correct one


## why

extesions/v1beta1 has been deprecated for a long time

## tests

no need

## references

closes #276 

