### PR TITLE
fix(tests): switch dduportal/bats to bats/bats

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.23.5
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.12.4
+version: 4.12.5
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/tests/test-atlantis-pod.yaml
+++ b/charts/atlantis/templates/tests/test-atlantis-pod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   initContainers:
     - name: test-framework
-      image: dduportal/bats:0.4.0
+      image: bats/bats:v1.9.0
       command:
       - "bash"
       - "-c"


### PR DESCRIPTION
## what

Users that deploy Atlantis with tests enabled experience the following error:
```
Failed to pull image "dduportal/bats:0.4.0": rpc error: code = Unknown desc = Error response from daemon: pull access denied for dduportal/bats, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

## why

dduportal/bats is no longer available at the repository specified. We need to switch to another repo.

## tests

- [x] I have tested my changes by checking the ability to download the new image 

## references

https://github.com/dduportal-dockerfiles/bats/issues/10
https://github.com/helm/charts/pull/19526

