### PR TITLE
feat(ingress): Allow creating secondary ingress

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,15 +3,15 @@ apiVersion: v1
 appVersion: v0.23.5
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.12.5
+version: 4.13.0
 keywords:
-- terraform
+  - terraform
 home: https://www.runatlantis.io
 icon: https://www.runatlantis.io/hero.png
 sources:
-- https://github.com/runatlantis/atlantis
+  - https://github.com/runatlantis/atlantis
 maintainers:
-- name: lkysow
-- name: jamengual
-- name: chenrui333
-- name: nitrocode
+  - name: lkysow
+  - name: jamengual
+  - name: chenrui333
+  - name: nitrocode

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -5,13 +5,13 @@ description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
 version: 4.13.0
 keywords:
-  - terraform
+- terraform
 home: https://www.runatlantis.io
 icon: https://www.runatlantis.io/hero.png
 sources:
-  - https://github.com/runatlantis/atlantis
+- https://github.com/runatlantis/atlantis
 maintainers:
-  - name: lkysow
-  - name: jamengual
-  - name: chenrui333
-  - name: nitrocode
+- name: lkysow
+- name: jamengual
+- name: chenrui333
+- name: nitrocode

--- a/charts/atlantis/ci/ci-values.yaml
+++ b/charts/atlantis/ci/ci-values.yaml
@@ -7,6 +7,17 @@ github:
 service:
   type: ClusterIP
 
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  host: atlantis.localdev.me
+  path: /
+secondary_ingress:
+  enabled: true
+  ingressClassName: nginx
+  host: atlantis-webook.localdev.me
+  path: /events
+
 resources:
   requests:
     memory: 64Mi

--- a/charts/atlantis/templates/secondary-ingress.yaml
+++ b/charts/atlantis/templates/secondary-ingress.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.secondary_ingress.enabled -}}
+{{- $apiVersion := .Values.secondary_ingress.apiVersion }}
+{{- if and $apiVersion (or (eq $apiVersion "networking.k8s.io/v1") (eq $apiVersion "networking.k8s.io/v1beta1") (eq $apiVersion "extensions/v1beta1")) -}}
+{{- else -}}
+  {{- $kubeVersion := .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.19-0" $kubeVersion -}}
+    {{- $apiVersion = "networking.k8s.io/v1" -}}
+  {{- else if semverCompare ">=1.14-0" $kubeVersion -}}
+    {{- $apiVersion = "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- $apiVersion = "extensions/v1beta1" -}}
+  {{- end }}
+{{- end }}
+{{- $fullName := include "atlantis.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $pathType := .Values.secondary_ingress.pathType -}}
+apiVersion: {{ $apiVersion }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-secondary
+  labels:
+{{- include "atlantis.labels" . | nindent 4 }}
+{{- if .Values.secondary_ingress.labels }}
+{{ toYaml .Values.secondary_ingress.labels | indent 4 }}
+{{- end }}
+{{- with .Values.secondary_ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.secondary_ingress.ingressClassName }}
+  ingressClassName: {{ .Values.secondary_ingress.ingressClassName }}
+{{- end }}
+{{- if .Values.secondary_ingress.tls }}
+  tls:
+{{ toYaml .Values.secondary_ingress.tls | indent 4 }}
+{{- end }}
+  rules:
+    {{- if not .Values.secondary_ingress.hosts }}
+    -
+      {{- if .Values.secondary_ingress.host }}
+      host: {{ .Values.secondary_ingress.host | quote }}
+      {{- end }}
+      http:
+        paths:
+        {{- if .Values.secondary_ingress.paths }}
+          {{- range .Values.secondary_ingress.paths }}
+          - path: {{ .path }}
+            backend:
+            {{- if eq $apiVersion "networking.k8s.io/v1" }}
+              service:
+                name: {{ .service }}
+                port:
+                  number: {{ .port }}
+            pathType: {{ $.Values.secondary_ingress.pathType }}
+            {{- else }}
+              serviceName: {{ .service }}
+              servicePort: {{ .port }}
+            {{- end }}
+          {{- end }}
+        {{ else }}
+          - path: {{ .Values.secondary_ingress.path }}
+            backend:
+            {{- if eq $apiVersion "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .Values.service.port }}
+            pathType: {{ .Values.secondary_ingress.pathType }}
+            {{ else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ .Values.service.port }}
+            {{- end }}
+        {{- end }}
+    {{ else }}
+    {{- range $k := .Values.secondary_ingress.hosts }}
+    -
+      {{- if .host }}
+      host: {{ .host | quote }}
+      {{- end }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              {{- if eq $apiVersion "networking.k8s.io/v1" }}
+              service:
+                {{- if $k.service }}
+                name: {{ $k.service }}
+                {{- else }}
+                name: {{ $fullName }}
+                {{- end }}
+                port:
+                  number: {{ $svcPort }}
+            pathType: {{ $pathType }}
+              {{- else -}}
+                {{- if $k.service }}
+              serviceName: {{ $k.service }}
+                {{- else }}
+              serviceName: {{ $fullName }}
+                {{- end }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -70,24 +70,24 @@ github: {}
 # When referencing Terraform modules in private repositories, it may be helpful
 # (necessary?) to use redirection in a .gitconfig like so:
 # gitconfig: |
-  # [url "https://YOUR_GH_TOKEN@github.com"]
-  #   insteadOf = https://github.com
-  # [url "https://YOUR_GH_TOKEN@github.com"]
-  #   insteadOf = ssh://git@github.com
-  # [url "https://oauth2:YOUR_GITLAB_TOKEN@gitlab.com"]
-  #   insteadOf = https://gitlab.com
-  # [url "https://oauth2:YOUR_GITLAB_TOKEN@gitlab.com"]
-  #   insteadOf = ssh://git@gitlab.com
+# [url "https://YOUR_GH_TOKEN@github.com"]
+#   insteadOf = https://github.com
+# [url "https://YOUR_GH_TOKEN@github.com"]
+#   insteadOf = ssh://git@github.com
+# [url "https://oauth2:YOUR_GITLAB_TOKEN@gitlab.com"]
+#   insteadOf = https://gitlab.com
+# [url "https://oauth2:YOUR_GITLAB_TOKEN@gitlab.com"]
+#   insteadOf = ssh://git@gitlab.com
 # Source: https://stackoverflow.com/questions/42148841/github-clone-with-oauth-access-token
 
 # If managing secrets outside the chart for the gitconfig, use this variable to reference the secret name
- # gitconfigSecretName: 'mygitconfigsecret'
+# gitconfigSecretName: 'mygitconfigsecret'
 
 # When referencing Terraform modules in private repositories or registries (such as Artfactory)
 # configuing a .netrc file for authentication may be required:
 # netrc: |
-  # machine artifactory.myapp.com login YOUR_USERNAME password YOUR_PASSWORD
-  # machine bitbucket.myapp.com login YOUR_USERNAME password YOUR_PASSWORD
+# machine artifactory.myapp.com login YOUR_USERNAME password YOUR_PASSWORD
+# machine bitbucket.myapp.com login YOUR_USERNAME password YOUR_PASSWORD
 
 # If managing secrets outside the chart for the netrc file, use this variable to reference the secret name
 # netrcSecretName: 'mynetrcsecret'
@@ -111,7 +111,6 @@ aws: {}
 serviceAccountSecrets:
   # credentials: <json file as base64 encoded string>
   # credentials-staging: <json file as base64 encoded string>
-
 
 ## -------------------------- ##
 # Default values for atlantis (override as needed).
@@ -218,7 +217,8 @@ service:
   loadBalancerIP: null
 
 podTemplate:
-  annotations: {}
+  annotations:
+    {}
     # kube2iam example:
     # iam.amazonaws.com/role: role-arn
   labels: {}
@@ -243,22 +243,57 @@ ingress:
   enabled: true
   ingressClassName:
   apiVersion: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /*
-## this is in case we want several paths under the same host, with different backend services
-#  paths:
-#    - path: "/path1"
-#      service: test1
-#      port:
-#    - path: "/path2"
-#      service: test2
-#      port:
+  ## this is in case we want several paths under the same host, with different backend services
+  #  paths:
+  #    - path: "/path1"
+  #      service: test1
+  #      port:
+  #    - path: "/path2"
+  #      service: test2
+  #      port:
   pathType: ImplementationSpecific
   host:
 
-## in case we need several hosts:
+  ## in case we need several hosts:
+  hosts:
+  #   - host: chart-example.local
+  #     paths: ["/"]
+  #     service: chart-example1
+  #   - host: chart-example.local2
+  #     service: chart-example1
+  #     paths: ["/lala"]
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+  labels: {}
+
+private_ingress: # Create secondary ingress for exposing webhooks publically.
+  enabled: false
+  ingressClassName:
+  apiVersion: ""
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /*
+  ## this is in case we want several paths under the same host, with different backend services
+  #  paths:
+  #    - path: "/path1"
+  #      service: test1
+  #      port:
+  #    - path: "/path2"
+  #      service: test2
+  #      port:
+  pathType: ImplementationSpecific
+  host:
+
+  ## in case we need several hosts:
   hosts:
   #   - host: chart-example.local
   #     paths: ["/"]

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -70,24 +70,24 @@ github: {}
 # When referencing Terraform modules in private repositories, it may be helpful
 # (necessary?) to use redirection in a .gitconfig like so:
 # gitconfig: |
-# [url "https://YOUR_GH_TOKEN@github.com"]
-#   insteadOf = https://github.com
-# [url "https://YOUR_GH_TOKEN@github.com"]
-#   insteadOf = ssh://git@github.com
-# [url "https://oauth2:YOUR_GITLAB_TOKEN@gitlab.com"]
-#   insteadOf = https://gitlab.com
-# [url "https://oauth2:YOUR_GITLAB_TOKEN@gitlab.com"]
-#   insteadOf = ssh://git@gitlab.com
+  # [url "https://YOUR_GH_TOKEN@github.com"]
+  #   insteadOf = https://github.com
+  # [url "https://YOUR_GH_TOKEN@github.com"]
+  #   insteadOf = ssh://git@github.com
+  # [url "https://oauth2:YOUR_GITLAB_TOKEN@gitlab.com"]
+  #   insteadOf = https://gitlab.com
+  # [url "https://oauth2:YOUR_GITLAB_TOKEN@gitlab.com"]
+  #   insteadOf = ssh://git@gitlab.com
 # Source: https://stackoverflow.com/questions/42148841/github-clone-with-oauth-access-token
 
 # If managing secrets outside the chart for the gitconfig, use this variable to reference the secret name
-# gitconfigSecretName: 'mygitconfigsecret'
+ # gitconfigSecretName: 'mygitconfigsecret'
 
 # When referencing Terraform modules in private repositories or registries (such as Artfactory)
 # configuing a .netrc file for authentication may be required:
 # netrc: |
-# machine artifactory.myapp.com login YOUR_USERNAME password YOUR_PASSWORD
-# machine bitbucket.myapp.com login YOUR_USERNAME password YOUR_PASSWORD
+  # machine artifactory.myapp.com login YOUR_USERNAME password YOUR_PASSWORD
+  # machine bitbucket.myapp.com login YOUR_USERNAME password YOUR_PASSWORD
 
 # If managing secrets outside the chart for the netrc file, use this variable to reference the secret name
 # netrcSecretName: 'mynetrcsecret'
@@ -111,6 +111,7 @@ aws: {}
 serviceAccountSecrets:
   # credentials: <json file as base64 encoded string>
   # credentials-staging: <json file as base64 encoded string>
+
 
 ## -------------------------- ##
 # Default values for atlantis (override as needed).
@@ -217,8 +218,7 @@ service:
   loadBalancerIP: null
 
 podTemplate:
-  annotations:
-    {}
+  annotations: {}
     # kube2iam example:
     # iam.amazonaws.com/role: role-arn
   labels: {}
@@ -241,25 +241,20 @@ statefulSet:
 
 ingress:
   enabled: true
-  ingressClassName:
-  apiVersion: ""
-  annotations:
-    {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  ingressClassName: nginx
   path: /*
-  ## this is in case we want several paths under the same host, with different backend services
-  #  paths:
-  #    - path: "/path1"
-  #      service: test1
-  #      port:
-  #    - path: "/path2"
-  #      service: test2
-  #      port:
+## this is in case we want several paths under the same host, with different backend services
+#  paths:
+#    - path: "/path1"
+#      service: test1
+#      port:
+#    - path: "/path2"
+#      service: test2
+#      port:
   pathType: ImplementationSpecific
   host:
 
-  ## in case we need several hosts:
+## in case we need several hosts:
   hosts:
   #   - host: chart-example.local
   #     paths: ["/"]
@@ -273,27 +268,26 @@ ingress:
   #      - chart-example.local
   labels: {}
 
-private_ingress: # Create secondary ingress for exposing webhooks publically.
+secondary_ingress:
   enabled: false
   ingressClassName:
   apiVersion: ""
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /*
-  ## this is in case we want several paths under the same host, with different backend services
-  #  paths:
-  #    - path: "/path1"
-  #      service: test1
-  #      port:
-  #    - path: "/path2"
-  #      service: test2
-  #      port:
+## this is in case we want several paths under the same host, with different backend services
+#  paths:
+#    - path: "/path1"
+#      service: test1
+#      port:
+#    - path: "/path2"
+#      service: test2
+#      port:
   pathType: ImplementationSpecific
   host:
 
-  ## in case we need several hosts:
+## in case we need several hosts:
   hosts:
   #   - host: chart-example.local
   #     paths: ["/"]

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -273,7 +273,7 @@ ingress:
   labels: {}
 
 webhook_ingress:
-  enabled: false
+  enabled: false # true to create secondary webhook.
   ingressClassName:
   apiVersion: ""
   annotations: {}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -273,7 +273,7 @@ ingress:
   labels: {}
 
 webhook_ingress:
-  enabled: false # true to create secondary webhook.
+  enabled: false  # true to create secondary webhook.
   ingressClassName:
   apiVersion: ""
   annotations: {}


### PR DESCRIPTION
## what

Allow creating a secondary ingress

## why

We want to be able to expose Atlantis to gitlab webhooks coming one network, while only allowing access to the Atlantis UI from our internal network/

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references
- closes #282 

