### PR TITLE
feat: add support for hostNetwork

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.25.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.15.0
+version: 4.15.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -41,6 +41,7 @@ spec:
           ip: {{ .ip }}
       {{- end }}
       {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
       serviceAccountName: {{ template "atlantis.serviceAccountName" . }}
       shareProcessNamespace: {{ .Values.statefulSet.shareProcessNamespace }}
       automountServiceAccountToken: {{ .Values.serviceAccount.mount }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -464,6 +464,8 @@ initContainers: []
 #     - bbb.com
 #     ip: 10.0.0.2
 
+hostNetwork: false
+
 extraArgs: []
 # extraArgs:
 # - --disable-autoplan


### PR DESCRIPTION
## what

What it says in the title


## why

Our atlantis instance runs in an EKS IPv6-only cluster, and thus cannot contact the EKS control plane (which is ipv4-only) if not run with hostNetwork, as the nodes are dual stack.

## tests

- [x] I have tested my changes by running this in production.

## references

None

