### PR TITLE
fix: don't define resources

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.24.3
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.13.2
+version: 4.13.3
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.24.3
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.13.1
+version: 4.13.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -309,13 +309,13 @@ webhook_ingress:
 # You have to create a secret `my-ca-certificates`
 # customPem: my-ca-certificates
 
-resources:
-  requests:
-    memory: 1Gi
-    cpu: 100m
-  limits:
-    memory: 1Gi
-    cpu: 100m
+resources: {}
+  # requests:
+  #   memory: 1Gi
+  #   cpu: 100m
+  # limits:
+  #   memory: 1Gi
+  #   cpu: 100m
 
 ## Embedded data volume & volumeMount (default working)
 volumeClaim:


### PR DESCRIPTION
## what

Remove cpu limits from the atlantis container

## why

Atlantis simply dies on simple tasks like `terraform init` with the current configuration.

## tests

- [x] I have tested my changes by running them in production.

## references

https://home.robusta.dev/blog/stop-using-cpu-limits