### PR TITLE
ci(helm/chart-testing): update github action

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -12,23 +12,47 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.10.3 # renovate: datasource=github-releases depName=helm packageName=helm/helm
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed \
+            --config ct.yaml \
+            --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run chart-testing (lint)
-        id: lint
-        uses: helm/chart-testing-action@v2.4.0
-        with:
-          command: lint
-          config: ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          ct lint \
+            --config ct.yaml \
+            --target-branch ${{ github.event.repository.default_branch }}
+
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.7.0
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.4.0
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v2.4.0
-        with:
-          command: install
-          config: ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          ct install \
+            --config ct.yaml \
+            --target-branch ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
## what

Update helm/chart-testing action to the latest [example workflow](https://github.com/helm/chart-testing-action/tree/v2.4.0/#example-workflow)

## why

Looks like the action has been failing silently with the warnings:

<img width="842" alt="image" src="https://github.com/runatlantis/helm-charts/assets/19713226/dc79560c-cf02-4448-a7ab-93a6607c3609">

## tests

N/A

## references

Bump chart was not detected by the action -> https://github.com/runatlantis/helm-charts/pull/297#issuecomment-1568497204

