### PR TITLE
Remove random prefix for test pod

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.24.3
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.13.1
+version: 4.13.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/tests/test-atlantis-pod.yaml
+++ b/charts/atlantis/templates/tests/test-atlantis-pod.yaml
@@ -2,9 +2,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ .Release.Name }}-ui-test-{{ randAlphaNum 5 | lower }}"
+  name: "{{ .Release.Name }}-ui-test"
   annotations:
     helm.sh/hook: test
+    {{- with .Values.test.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
 spec:
   containers:
     - name: {{ .Release.Name }}-ui-test

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -338,6 +338,7 @@ test:
   enabled: true
   image: bats/bats
   imageTag: 1.9.0
+  annotations: {}
 
 nodeSelector: {}
 


### PR DESCRIPTION
Also added annotations for test pod manifest.

## what
Remove random prefix for test pod name.
Also added annotations for test pod manifest.


## why
It is bad practice to user random prefix in name.

- this leads to problems when using kustomize because the searching resource is implemented via name search.
- if it necessary, random value can be passed via annotation.
- in some cases generated templates need to be without diff.
## tests

local, by compare templates
with empty and filled .Values.test.annotations
