### PR TITLE
ci(helm): fix and simplify bats logic

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.24.2
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.12.6
+version: 4.12.7
 keywords:
 - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/ci/ci-values.yaml
+++ b/charts/atlantis/ci/ci-values.yaml
@@ -3,3 +3,14 @@ github:
   user: foo
   token: bar
   secret: baz
+
+service:
+  type: ClusterIP
+
+resources:
+  requests:
+    memory: 64Mi
+    cpu: 10m
+  limits:
+    memory: 128Mi
+    cpu: 100m

--- a/charts/atlantis/templates/tests/test-atlantis-configmap.yaml
+++ b/charts/atlantis/templates/tests/test-atlantis-configmap.yaml
@@ -4,10 +4,13 @@ kind: ConfigMap
 metadata:
   name: {{ template "atlantis.fullname" . }}-tests
 data:
-  run.sh: |-
+  tests.bats: |-
+    setup() {
+      apk add curl -q
+    }
     @test "Atlantis UI is available" {
       ATLANTIS_URL={{ template "atlantis.url" . }}
       echo "Trying Atlantis at: $ATLANTIS_URL"
-      curl $ATLANTIS_URL
+      curl -v $ATLANTIS_URL
     }
 {{- end }}

--- a/charts/atlantis/templates/tests/test-atlantis-pod.yaml
+++ b/charts/atlantis/templates/tests/test-atlantis-pod.yaml
@@ -4,36 +4,19 @@ kind: Pod
 metadata:
   name: "{{ .Release.Name }}-ui-test-{{ randAlphaNum 5 | lower }}"
   annotations:
-    "helm.sh/hook": test-success
+    helm.sh/hook: test
 spec:
-  initContainers:
-    - name: test-framework
-      image: bats/bats:v1.9.0
-      command:
-      - "bash"
-      - "-c"
-      - |
-        set -ex
-        # copy bats to tools dir
-        cp -R /usr/local/libexec/ /tools/bats/
-      volumeMounts:
-      - mountPath: /tools
-        name: tools
   containers:
     - name: {{ .Release.Name }}-ui-test
       image: {{ .Values.test.image }}:{{ .Values.test.imageTag }}
-      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      command: ["/usr/local/bin/bats", "/tests/"]
       volumeMounts:
       - mountPath: /tests
         name: tests
         readOnly: true
-      - mountPath: /tools
-        name: tools
   volumes:
   - name: tests
     configMap:
       name: {{ template "atlantis.fullname" . }}-tests
-  - name: tools
-    emptyDir: {}
   restartPolicy: Never
 {{- end }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -303,8 +303,8 @@ replicaCount: 1
 ## test container details
 test:
   enabled: true
-  image: lachlanevenson/k8s-kubectl
-  imageTag: v1.4.8-bash
+  image: bats/bats
+  imageTag: 1.9.0
 
 nodeSelector: {}
 


### PR DESCRIPTION
## what

- Fix helm test
- Simplify logic by using the bats image directly

## why

- Closes https://github.com/runatlantis/helm-charts/issues/292

## tests

- Tested locally with:
    ```sh
    kind create cluster --name test-atlantis
    helm upgrade -i atlantis charts/atlantis -f ci/ci-values.yaml
    helm test atlantis
    kind delete cluster --name test-atlantis
    ```
