### PR TITLE
feat: bump app version to 0.24.4

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 # renovate datasource=docker depName=ghcr.io/runatlantis/atlantis
-appVersion: v0.24.3
+appVersion: v0.24.4
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.13.3
+version: 4.14.0
 keywords:
   - terraform
 home: https://www.runatlantis.io
@@ -15,3 +15,4 @@ maintainers:
   - name: jamengual
   - name: chenrui333
   - name: nitrocode
+  - name: genpage


### PR DESCRIPTION
## what

- bump app version to 0.24.4

## references

https://github.com/runatlantis/atlantis/releases/tag/v0.24.4

