### PR TITLE
release: bump atlantis to 0.25.0

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 # renovate datasource=docker depName=ghcr.io/runatlantis/atlantis
-appVersion: v0.24.4
+appVersion: v0.25.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.14.2
+version: 4.15.0
 keywords:
   - terraform
 home: https://www.runatlantis.io


### PR DESCRIPTION
## what

relates to https://github.com/runatlantis/atlantis/releases/tag/v0.25.0

