### PR TITLE
commenting out default servicemonitor auth to avoid checkov CKV_SECRET_6

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.25.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.15.1
+version: 4.15.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.25.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.15.2
+version: 4.15.3
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -510,8 +510,8 @@ servicemonitor:
       enabled: false
       # name: atlantis-env
       # keys:
-        # username: USERNAME
-        # password: ATLANTIS_WEB_PASSWORD
+      #   username: USERNAME
+      #   password: ATLANTIS_WEB_PASSWORD
 
 # Enable this if you're using Google Managed Prometheus
 podMonitor:

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -508,10 +508,10 @@ servicemonitor:
     externalSecret:
       # authentication based on an external secret
       enabled: false
-      name: atlantis-env
-      keys:
-        username: USERNAME
-        password: ATLANTIS_WEB_PASSWORD
+      # name: atlantis-env
+      # keys:
+        # username: USERNAME
+        # password: ATLANTIS_WEB_PASSWORD
 
 # Enable this if you're using Google Managed Prometheus
 podMonitor:


### PR DESCRIPTION


## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Commenting out the default password and username setting for service monitor authentication to avoid running into the checkov SECRET_6 compliance check.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

Since its disabled by default any way there should be no harm in commenting out the actual setting of the password and prevents people from deploying with a default password if they do enable the auth check for the service monitor. Commented out and left for reference of users that want to set it.

## tests

<!--
- [ ] I have tested my changes by ...
-->

Running checkov against charts with it commented out does not make the error occur.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

