### PR TITLE
feat: allow configurable data directory path

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.25.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.15.1
+version: 4.15.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -237,7 +237,7 @@ spec:
             value: /etc/tls/tls.key
           {{- end }}
           - name: ATLANTIS_DATA_DIR
-            value: /atlantis-data
+            value: {{ .Values.atlantisDataDirectory }}
           - name: ATLANTIS_REPO_ALLOWLIST
             value: {{ toYaml (coalesce .Values.orgWhitelist .Values.orgAllowlist) }}
           - name: ATLANTIS_PORT
@@ -435,7 +435,7 @@ spec:
           volumeMounts:
           {{- if or .Values.volumeClaim.enabled .Values.dataStorage  }}
           - name: atlantis-data
-            mountPath: /atlantis-data
+            mountPath: {{ .Values.atlantisDataDirectory }}
           {{- end }}
           {{- range $name, $_ := .Values.serviceAccountSecrets }}
           - name: {{ $name }}-volume

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -321,6 +321,9 @@ resources: {}
   #   memory: 1Gi
   #   cpu: 100m
 
+## Path to the data directory for the volumeMount
+atlantisDataDirectory: /atlantis-data
+
 ## Embedded data volume & volumeMount (default working)
 volumeClaim:
   enabled: true


### PR DESCRIPTION
## what
- Allow the path to the Atlantis Data directory to be configured.

## why
- When we initially deployed Atlantis we preferred the data directory path to be differently named. We now have custom workflows that refer to our custom path name.

## tests
- Used modified chart to deploy to our test and production environments.

## references
none
