### PR TITLE
release: update atlantis to v0.26.0

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 # renovate datasource=docker depName=ghcr.io/runatlantis/atlantis
-appVersion: v0.25.0
+appVersion: v0.26.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.15.3
+version: 4.16.0
 keywords:
   - terraform
 home: https://www.runatlantis.io


### PR DESCRIPTION
[v0.26.0](https://github.com/runatlantis/atlantis/releases/tag/v0.26.0) was released a few weeks ago