### PR TITLE
Add loadBalancerSourceRanges to schema

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.26.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.17.0
+version: 4.17.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.26.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.17.1
+version: 4.17.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -484,6 +484,13 @@
             "string",
             "null"
           ]
+        },
+        "loadBalancerSourceRanges":{
+          "description":"If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.",
+          "type":[
+            "array",
+            "null"
+          ]
         }
       }
     },

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -234,6 +234,7 @@ service:
   nodePort: null
   targetPort: 4141
   loadBalancerIP: null
+  loadBalancerSourceRanges: []
 
 podTemplate:
   annotations: {}


### PR DESCRIPTION
## what

Add loadBalancerSourceRanges to schema


## why

The loadBalancerSourceRanges is an existing param in the chart, but passing it to the chart after the schema was added results in `- service: Additional property loadBalancerSourceRanges is not allowed` error.

## tests

Applied with passing the value and without passing the value.


