### PR TITLE
Fix values.schema.json -  containerSecurityContext is an instance of io.k8s.api.core.v1.SecurityContext

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.26.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.17.4
+version: 4.17.5
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1036,17 +1036,7 @@
     "containerSecurityContext":{
       "type":"object",
       "description":"SecurityContext configuration for atlantis containers.",
-      "properties":{
-        "allowPrivilegeEscalation":{
-          "type":"boolean",
-          "description":"Whether to enable privilege escalation"
-        },
-        "readOnlyRootFilesystem":{
-          "type":"boolean",
-          "description":"Whether the root file system should be read-only"
-        }
-      },
-      "additionalProperties":false
+      "$ref":"#/definitions/io.k8s.api.core.v1.SecurityContext"
     },
     "servicemonitor":{
       "type":"object",


### PR DESCRIPTION
## what

Update the JSON schema to reflect that `containerSecurityContext` in `values.yaml` can be an instance of [`io.k8s.api.core.v1.SecurityContext`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)

## why

To allow the full range of Security Context settings, for instance, we use `capabilities`.

## tests

Checked with https://www.jsonschemavalidator.net/

## references

N/A
