### PR TITLE
ci(stale): add action to cleanup stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: Close Stale PRs
+on:
+  schedule:
+    - cron: '30 1 * * *'
+jobs:
+  stale:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: 'This issue is stale because it has been open for 1 month with no activity. Remove stale label or comment or this will be closed in 1 month.'
+          stale-issue-message: This issue is stale because it has been open for 1 month with no activity. Remove stale label or comment or this will be closed in 1 month.'
+          remove-stale-when-updated: true
+          exempt-pr-labels: "never-stale"
+          exempt-issue-labels: "never-stale"
+          # 1 month
+          days-before-stale: 31
+          # 1 month
+          days-before-close: 31
+          only-labels: 'waiting-on-response'


### PR DESCRIPTION
## what

As discussed on [slack](https://atlantis-community.slack.com/archives/C04ES70Q6E8/p1709114536848619).

## why

Keep issues and PRs clean.