### PR TITLE
fix: Changed runAsUser uid

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -260,7 +260,7 @@ statefulSet:
   labels: {}
   securityContext:
     fsGroup: 1000
-    runAsUser: 100
+    runAsUser: 1000
     fsGroupChangePolicy: "OnRootMismatch"
   priorityClassName: ""
   updateStrategy: {}


### PR DESCRIPTION
## what
This changes the default runAsUser uid to 1000 instead of 100
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why
Together with https://github.com/runatlantis/atlantis/pull/4304 this will fix #305. This should only be merged when https://github.com/runatlantis/atlantis/pull/4304 has been released.
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references
Closes #305 
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

