### PR TITLE
fix pvc labels indent

### DIFF
--- a/charts/atlantis/templates/pvc.yaml
+++ b/charts/atlantis/templates/pvc.yaml
@@ -3,8 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "atlantis.fullname" . }}-data
-labels:
-  {{- include "atlantis.labels" . | nindent 2 }}
+  labels:
+    {{- include "atlantis.labels" . | nindent 4 }}
 spec:
   accessModes: {{ .Values.volumeClaim.accessModes| toYaml | nindent 2 }}
   resources:


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
Fix PVC `labels` indent.
Ref: https://github.com/runatlantis/helm-charts/pull/304


## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

I got the following error with `v4.22.0`.
```
Error from server (BadRequest): error when creating "STDIN": PersistentVolumeClaim in version "v1" cannot be handled as a PersistentVolumeClaim: strict decoding error: unknown field "labels"
```

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

