### PR TITLE
fix: fix indentation of repos.yaml in configmap-repo-config

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.27.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.23.0
+version: 4.23.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/configmap-repo-config.yaml
+++ b/charts/atlantis/templates/configmap-repo-config.yaml
@@ -11,5 +11,5 @@ metadata:
   {{- end }}
 data:
   repos.yaml: |
-    {{- .Values.repoConfig | indent 4 }}
+    {{- .Values.repoConfig | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
The last release v4.23.0 contains a typo / bug in the `configmap-repo-config.yaml` template where a `indent` is used instead of `nindent`, causing a templating error if the `repoConfig` value is set.


