### PR TITLE
fix(patch-1): ingress's annotation indentation fixed

### DIFF
--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -26,10 +26,10 @@ metadata:
   {{- if or .Values.ingress.annotations .Values.extraAnnotations }}
   annotations:
     {{- with .Values.ingress.annotations }}
-    {{- toYaml . | indent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with .Values.extraAnnotations }}
-    {{- toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:


### PR DESCRIPTION
## what

<!--
- Version 4.22 extraAnnotations broke the indentation and it was leading to failure on ingress.
-->


## why

<!--
- This caused it to following failure on helm template .
- ```
Error: YAML parse error on atlantis/charts/atlantis/templates/ingress.yaml: error converting YAML to JSON: yaml: line 11: mapping values are not allowed in this context
helm.go:84: [debug] error converting YAML to JSON: yaml: line 11: mapping values are not allowed in this context
YAML parse error on atlantis/charts/atlantis/templates/ingress.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
	helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
	helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
	helm.sh/helm/v3/pkg/action/action.go:168
helm.sh/helm/v3/pkg/action.(*Install).RunWithContext
	helm.sh/helm/v3/pkg/action/install.go:304
main.runInstall
	helm.sh/helm/v3/cmd/helm/install.go:306
main.newTemplateCmd.func2
	helm.sh/helm/v3/cmd/helm/template.go:95
github.com/spf13/cobra.(*Command).execute
	github.com/spf13/cobra@v1.7.0/command.go:940
github.com/spf13/cobra.(*Command).ExecuteC
	github.com/spf13/cobra@v1.7.0/command.go:1068
github.com/spf13/cobra.(*Command).Execute
	github.com/spf13/cobra@v1.7.0/command.go:992
main.main
	helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
	runtime/proc.go:267
runtime.goexit
	runtime/asm_arm64.s:1197
```
-->

## tests

<!--
- [X] I have tested my changes by building template locally with enabled ingress.
- `  enabled: true
  ingressClassName: nginx
  path: /*
  pathType: ImplementationSpecific
  host: atlantis.example.com
  annotations:
    external-dns.alpha.kubernetes.io/zone: public
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/rewrite-target: /
`
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

