### PR TITLE
fix: fix nil pointer error with StatefulSet labels when set

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.27.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.23.2
+version: 4.23.3
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ template "atlantis.fullname" . }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
-    {{ with .Values.statefulSet.labels }}
-    {{- toYaml .Values.statefulSet.labels | nindent 4 }}
+    {{- with .Values.statefulSet.labels }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if or .Values.statefulSet.annotations .Values.extraAnnotations }}
   annotations:


### PR DESCRIPTION
## what

Fix nil pointer error with StatefulSet labels when set, introduced in #356.

## why

```
    [ERROR] templates/: template: atlantis/templates/statefulset.yaml:8:22: executing "atlantis/templates/statefulset.yaml" at <.Values.statefulSet.labels>: nil pointer evaluating interface {}.statefulSet
```

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

https://github.com/runatlantis/helm-charts/pull/356#discussion_r1516867355