### PR TITLE
fix: fix values.schema.json for extraArgs

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.27.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.23.3
+version: 4.23.4
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1055,7 +1055,7 @@
       "type": "array",
       "description": "These annotations will be added to all the resources",
       "items": {
-        "type": "object"
+        "type": "string"
       },
       "examples": {
         "team": "example"


### PR DESCRIPTION
## what
Fixes #365. This changes the array item type back to string for extraArgs, which seems to have been erroneously changed in #356 
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why
Even if this wasn't erroneously, it should've been a breaking change.
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

