### PR TITLE
fix(helm-chart): prioritize orgAllowlist

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.27.2
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.24.0
+version: 4.24.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -155,7 +155,7 @@ extraManifests:
 | netrcSecretName | string | `""` | If managing secrets outside the chart for the netrc file, use this variable to reference the secret name |
 | nodeSelector | object | `{}` |  |
 | orgAllowlist | string | `"<replace-me>"` | Replace this with your own repo allowlist. |
-| orgWhitelist | string | `"<replace-me>"` | Deprecated in favor of orgAllowlist. |
+| orgWhitelist | string | `"<deprecated>"` | Deprecated in favor of orgAllowlist. |
 | podMonitor | object | `{"enabled":false,"interval":"30s"}` | Enable this if you're using Google Managed Prometheus. |
 | podTemplate.annotations | object | `{}` | Check values.yaml for examples. |
 | podTemplate.labels | object | `{}` |  |

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -287,7 +287,11 @@ spec:
           - name: ATLANTIS_DATA_DIR
             value: {{ .Values.atlantisDataDirectory }}
           - name: ATLANTIS_REPO_ALLOWLIST
-            value: {{ toYaml (coalesce .Values.orgWhitelist .Values.orgAllowlist) }}
+            {{- if .Values.orgAllowlist }}
+            value: {{ .Values.orgAllowlist | quote }}
+            {{- else }}
+            value: {{ .Values.orgWhitelist | quote }}
+            {{- end }}
           - name: ATLANTIS_PORT
             value: "4141"
           {{- if .Values.repoConfig }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -18,7 +18,7 @@ atlantisUrl: ""
 orgAllowlist: "<replace-me>"
 
 # -- Deprecated in favor of orgAllowlist.
-orgWhitelist: "<replace-me>"
+orgWhitelist: "<deprecated>"
 
 # -- Specify the log level for Atlantis.
 # Accepts: debug, info, warn, or error.


### PR DESCRIPTION
## what

- Reported on https://github.com/runatlantis/helm-charts/pull/371#discussion_r1547023529
- Ensure that `orgAllowlist` has priority over deprecated `orgWhitelist`

## why

Caused by https://github.com/runatlantis/helm-charts/pull/371.

## tests

Changed `orgWhitelist` default value to make sure the sts unit test uses the `orgAllowlist` default value.
