### PR TITLE
Adds securityContext to initConfig

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.27.2
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.24.1
+version: 4.25.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -134,6 +134,7 @@ extraManifests:
 | initConfig.image | string | `"alpine:latest"` |  |
 | initConfig.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initConfig.script | string | Check values.yaml. | Script to run on the init container. |
+| initConfig.securityContext | object | `{}` | Security context for the container. |
 | initConfig.sharedDir | string | `"/plugins"` | SharedDir is set as env var INIT_SHARED_DIR. |
 | initConfig.sizeLimit | string | `"100Mi"` | Size for the shared volume. |
 | initConfig.workDir | string | `"/tmp"` |  |

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -183,7 +183,7 @@ spec:
               mountPath: {{ .Values.initConfig.sharedDir }}
           {{- if .Values.initConfig.containerSecurityContext }}
           securityContext: {{- toYaml .Values.initConfig.containerSecurityContext | nindent 12 }}
-          {{- end }}
+          {{- end }}
         {{- end }}
       {{- end }}
       containers:

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -181,6 +181,9 @@ spec:
               subPath: init-config.sh
             - name: init-shared-path
               mountPath: {{ .Values.initConfig.sharedDir }}
+          {{- if .Values.initConfig.containerSecurityContext }}
+          securityContext: {{- toYaml .Values.initConfig.containerSecurityContext | nindent 12 }}
+          {{- end }}
         {{- end }}
       {{- end }}
       containers:

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1001,6 +1001,11 @@
           "type": "string",
           "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images"
         },
+        "containerSecurityContext": {
+          "type": "object",
+          "description": "SecurityContext configuration for the initConfig container.",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext"
+        },
         "sharedDir": {
           "type": "string",
           "description": "sharedDir is set as env var INIT_SHARED_DIR"

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -567,6 +567,8 @@ initConfig:
   workDir: /tmp
   # -- Size for the shared volume.
   sizeLimit: 100Mi
+  # -- Security context for the container.
+  securityContext: {}
   # -- Script to run on the init container.
   # @default -- Check values.yaml.
   script: |


### PR DESCRIPTION
## what

- Makes it an option to add a security context to the initConfig container

## why

- I'm running atlantis in a very restricted cluster and it needs a specific security context

## tests

- I rendered the template and it looks good

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

