### PR TITLE
ci(atlantis): fix super-linter

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,6 @@
+{
+    "ignore": [
+        "**/charts/atlantis/templates/**",
+        "**/charts/atlantis/tests/**"
+    ]
+}

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -10,6 +10,8 @@ defaults:
   run:
     shell: bash
 
+permissions: read-all
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -5,18 +5,21 @@ name: Lint Code Base
 
 on:
   pull_request:
-    paths:
-      - 'charts/atlantis/**'
+
+permissions: read-all
 
 jobs:
   build:
     name: Lint Code Base
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Lint Code Base
         uses: github/super-linter@v6
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,9 +7,13 @@ on:
     paths:
       - 'charts/atlantis/**'
 
+permissions: read-all
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,9 +2,15 @@ name: Close Stale PRs
 on:
   schedule:
     - cron: '30 1 * * *'
+
+permissions: read-all
+
 jobs:
   stale:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
## what

Fixes super-linter errors:
  - sets stricter permissions to clear `checkov` errors
  - excludes helm templates and tests from `jscpd` as it's expected to have duplicate content

## why

After updating super-linter on https://github.com/runatlantis/helm-charts/pull/377, we starting getting error with `checkov` and `jscpd`. E.g. [helm-charts/actions/runs/8912806968](https://github.com/runatlantis/helm-charts/actions/runs/8912806968/job/24476999190?pr=381).
