### PR TITLE
Bump appVersion to 0.27.3, chart to 4.25.1

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 # renovate: datasource=docker depName=ghcr.io/runatlantis/atlantis
-appVersion: v0.27.2
+appVersion: v0.27.3
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 4.25.0
+version: 4.25.1
 keywords:
   - terraform
 home: https://www.runatlantis.io


### PR DESCRIPTION
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Due to a breaking change in `go-getter` introduced in Terraform `v1.8.2` (see [docs](https://github.com/hashicorp/terraform/releases/tag/v1.8.2)), Atlantis functionality was degraded. A hotfix was then released: https://github.com/runatlantis/atlantis/issues/4471. This PR bumps the appVersion to the latest and increments the patch version of the chart accordingly 
