### PR TITLE
fix(atlantis): permissions for .gitconfig file

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.27.3
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.0.1
+version: 5.0.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -86,10 +86,12 @@ spec:
       {{- if .Values.gitconfig }}
       - name: gitconfig-volume
         secret:
+          defaultMode: 0660
           secretName: {{ template "atlantis.fullname" . }}-gitconfig
       {{- else if .Values.gitconfigSecretName }}
       - name: gitconfig-volume
         secret:
+          defaultMode: 0660
           secretName: {{ .Values.gitconfigSecretName }}
       {{- end }}
       {{- if .Values.netrc }}

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -332,6 +332,7 @@ tests:
           value:
             name: gitconfig-volume
             secret:
+              defaultMode: 432
               secretName: my-release-atlantis-gitconfig
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[?(@.name ==
@@ -351,6 +352,7 @@ tests:
           value:
             name: gitconfig-volume
             secret:
+              defaultMode: 432
               secretName: atlantis-gitconfig
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[?(@.name ==


### PR DESCRIPTION
## what

Fixes permissions for `/home/atlantis/.gitconfig` using `defaultMode` option

```yaml
→ kubectl explain statefulset.spec.template.spec.volumes.secret.defaultMode
GROUP:      apps
KIND:       StatefulSet
VERSION:    v1

FIELD: defaultMode <integer>


DESCRIPTION:
    defaultMode is Optional: mode bits used to set permissions on created files
    by default. Must be an octal value between 0000 and 0777 or a decimal value
    between 0 and 511. YAML accepts both octal and decimal values, JSON requires
    decimal values for mode bits. Defaults to 0644. Directories within the path
    are not affected by this setting. This might be in conflict with other
    options that affect the file mode, like fsGroup, and the result can be other
    mode bits set.
```

## why

Reported on https://github.com/runatlantis/helm-charts/issues/222 and https://github.com/runatlantis/atlantis/issues/1257 

## tests

After deploying the latest chart versions with a `gitconfig` value we can confirm that the `atlantis` user won't have permissions to write to the `/home/atlantis/.gitconfig` file:

```sh
atlantis-0:/$ ls -lha /home/atlantis/.gitconfig
-rw-r--r--    1 root     atlantis     180 May  4 11:52 /home/atlantis/.gitconfig
atlantis-0:/$
```

After deploying with the fix on this PR we can see the `atlantis` user will be allowed to write to the file:

```sh
atlantis-0:/$ ls -lha /home/atlantis/.gitconfig
-rw-rw----    1 root     atlantis     180 May  4 12:46 /home/atlantis/.gitconfig
atlantis-0:/$
```

`atlantis` is part of the `atlantis` group:

```sh
atlantis-0:/$ id
uid=100(atlantis) gid=1000(atlantis) groups=1000(atlantis)
```
## references

- Closes https://github.com/runatlantis/helm-charts/issues/222
- Closes https://github.com/runatlantis/atlantis/issues/1257 