### PR TITLE
Set aws file secrets as individual files

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.30.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.7.0
+version: 5.7.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -79,7 +79,7 @@ extraManifests:
 | atlantisDataDirectory | string | `"/atlantis-data"` | Path to the data directory for the volumeMount. |
 | atlantisUrl | string | `""` | An option to override the atlantis url, if not using an ingress, set it to the external IP. Check values.yaml for examples. |
 | aws | object | `{}` | To specify AWS credentials to be mapped to ~/.aws or to aws.directory. Check values.yaml for examples. |
-| awsSecretName | string | `""` | To reference an already existing Secret object with AWS credentials |
+| awsSecretName | string | `""` | To reference an already existing Secret object with AWS credentials. This has priority over the aws.config and aws.credential fields. |
 | azuredevops | object | `{}` | If using Azure DevOps, please enter your values as follows. The chart will perform the base64 encoding for you for values that are stored in secrets. Check values.yaml for examples. |
 | basicAuth | object | `{"password":"","username":""}` | Optionally specify an username and a password for basic authentication. |
 | basicAuthSecretName | string | `""` | If managing secrets outside the chart for the Basic Auth secret, use this variable to reference the secret name. |

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -565,10 +565,22 @@ spec:
             mountPath: /home/atlantis/.netrc
             subPath: netrc
           {{- end }}
-          {{- if or .Values.aws.credentials .Values.aws.config .Values.awsSecretName }}
+          {{- if .Values.awsSecretName }}
           - name: aws-volume
             readOnly: true
             mountPath: {{ .Values.aws.directory | default "/home/atlantis/.aws" }}
+          {{- else }}
+          {{- range $filename, $_ := .Values.aws }}
+          {{- if has $filename (list "credentials" "config") }}
+          - name: aws-volume
+            readOnly: true
+            mountPath: {{ $.Values.aws.directory | default "/home/atlantis/.aws" }}/{{ $filename }}
+            subPath: {{ $filename }}
+          {{- else if has $filename (list "awsSecretName") }}
+          - name: aws-volume
+            readOnly: true
+            mountPath: {{ $.Values.aws.directory | default "/home/atlantis/.aws" }}
+          {{- end }}
           {{- end }}
           {{- if .Values.tlsSecretName }}
           - name: tls

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -145,7 +145,7 @@ aws: {}
 #     source_profile = default
 #   directory: "/home/atlantis/.aws"
 
-# -- To reference an already existing Secret object with AWS credentials
+# -- To reference an already existing Secret object with AWS credentials. This has priority over the aws.config and aws.credential fields.
 awsSecretName: ""
 
 # -- To keep backwards compatibility only.


### PR DESCRIPTION
## what

creates config and credentials as files within .aws instead of mounting entire secret as .aws. 

## why

This allows for other directories (.aws/cli, .aws/sso) which need to be created/used by the CLI itself for caching to exist.

## tests

tested via various configuration of helm values to receive desired result.   Running in own environment the case where aws.config is specified.  Does assume that config/credentials is never specified along with awsSecretName.

## references

closes #380 
