### PR TITLE
✨ expose init-shared-path readOnly var

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.28.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.1.1
+version: 5.1.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -137,6 +137,7 @@ extraManifests:
 | initConfig.script | string | Check values.yaml. | Script to run on the init container. |
 | initConfig.securityContext | object | `{}` | Security context for the container. |
 | initConfig.sharedDir | string | `"/plugins"` | SharedDir is set as env var INIT_SHARED_DIR. |
+| initConfig.sharedDirReadOnly | bool | `true` |  |
 | initConfig.sizeLimit | string | `"100Mi"` | Size for the shared volume. |
 | initConfig.workDir | string | `"/tmp"` |  |
 | initContainers | list | `[]` | Optionally specify init containers manifests to be added to the Atlantis pod. Check values.yaml for examples. |
@@ -384,9 +385,9 @@ To perform a smoke test of the deployment (i.e. ensure that the Atlantis UI is u
 
 ## Update documentation
 
-Documentations is auto-generated using [helm-docs](https://github.com/norwoodj/helm-docs).
+Documentation is auto-generated using [helm-docs](https://github.com/norwoodj/helm-docs).
 
-To update run the follwogin (from the root path of the repository):
+To update run the following (from the root path of the repository):
 
 1. If required, update `charts/atlantis/README.md.gotmpl`
 2. Run `make docs`

--- a/charts/atlantis/README.md.gotmpl
+++ b/charts/atlantis/README.md.gotmpl
@@ -219,9 +219,9 @@ To perform a smoke test of the deployment (i.e. ensure that the Atlantis UI is u
 
 ## Update documentation
 
-Documentations is auto-generated using [helm-docs](https://github.com/norwoodj/helm-docs).
+Documentation is auto-generated using [helm-docs](https://github.com/norwoodj/helm-docs).
 
-To update run the follwogin (from the root path of the repository):
+To update run the following (from the root path of the repository):
 
 1. If required, update `charts/atlantis/README.md.gotmpl`
 2. Run `make docs`

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -567,7 +567,7 @@ spec:
           {{- if .Values.initConfig.enabled }}
           - name: init-shared-path
             mountPath: {{ .Values.initConfig.sharedDir }}
-            readOnly: true
+            readOnly: {{ .Values.initConfig.sharedDirReadOnly }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1012,7 +1012,7 @@
         },
         "sharedDirReadOnly": {
           "type": "boolean",
-          "description": "Let you mount SharedDir in ReadWrite or ReadOnly in the main container"
+          "description": "Sets permissions level for the SharedDir in the main container to ReadWrite when true or ReadWrite when false"
         },
         "workDir": {
           "type": "string",

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1010,6 +1010,10 @@
           "type": "string",
           "description": "sharedDir is set as env var INIT_SHARED_DIR"
         },
+        "sharedDirReadOnly": {
+          "type": "boolean",
+          "description": "Let you mount SharedDir in ReadWrite or ReadOnly in the main container"
+        },
         "workDir": {
           "type": "string",
           "description": "Starting directory for the script"

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -564,6 +564,7 @@ initConfig:
   imagePullPolicy: IfNotPresent
   # -- SharedDir is set as env var INIT_SHARED_DIR.
   sharedDir: /plugins
+  sharedDirReadOnly: true
   workDir: /tmp
   # -- Size for the shared volume.
   sizeLimit: 100Mi


### PR DESCRIPTION
## what

By default `init-shared-path` is read-only mounted without the possibility to mount it read-write. This PR expose the `readOnly` setting of the `volumeMount` to be able to manage it through values file.


## why

We used to build a custom `atlantis` image to be able to embed additional tools required by custom workflows defined server-side (like `aws-cli` or `asdf` to handle `terraform`, `terragrunt`, `opentofu`, `kubectl` and others). Although it works just fine, we had to maintain our custom image.
Since `initConfig` object, we have been able to move the instruction from our custom `Dockerfile` to the `initConfig.script` value.
The main issue is that the `initConfig.sharedDir` is mounted read-write on the init container, but is mounted read-only on the main container.
As we're using `asdf` is all our repositories with sometimes different versions for each tool, the `atlantis` image is installing these different versions of `terraform`/`opentofu`/`...` during the `pre_workflow_hooks` thanks to a `.tool-versions` in each repository. But `asdf` require to download and install each version where it was installed (ie in the `sharedDir`), thus require read-write `volumeMount`.

Today we're using `kustomize` to patch it so that it's mounted correctly, but we're hoping this could be handled directly through the chart itself:

```yaml
- op: replace
  path: /spec/template/spec/containers/0/volumeMounts/3/readOnly
  value: false
```