### PR TITLE
✏️ fix typo on var name

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.28.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.1.2
+version: 5.1.3
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -131,11 +131,11 @@ extraManifests:
 | ingress.pathType | string | `"ImplementationSpecific"` |  |
 | ingress.paths | list | `[]` | Used when several paths under the same host, with different backend services, are required. Check values.yaml for examples. |
 | ingress.tls | list | `[]` | Check values.yaml for examples. |
+| initConfig.containerSecurityContext | object | `{}` | Security context for the container. |
 | initConfig.enabled | bool | `false` | Install providers/plugins into a path shared with the Atlantis pod. |
 | initConfig.image | string | `"alpine:latest"` |  |
 | initConfig.imagePullPolicy | string | `"IfNotPresent"` |  |
 | initConfig.script | string | Check values.yaml. | Script to run on the init container. |
-| initConfig.securityContext | object | `{}` | Security context for the container. |
 | initConfig.sharedDir | string | `"/plugins"` | SharedDir is set as env var INIT_SHARED_DIR. |
 | initConfig.sharedDirReadOnly | bool | `true` |  |
 | initConfig.sizeLimit | string | `"100Mi"` | Size for the shared volume. |

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -569,7 +569,7 @@ initConfig:
   # -- Size for the shared volume.
   sizeLimit: 100Mi
   # -- Security context for the container.
-  securityContext: {}
+  containerSecurityContext: {}
   # -- Script to run on the init container.
   # @default -- Check values.yaml.
   script: |


### PR DESCRIPTION
## what

For security context on init container, you're using `.Values.initConfig.containerSecurityContext` (as seen in [here](https://github.com/runatlantis/helm-charts/blob/7693bfd4a0f8505d5ea74cfcc27f4e02064074df/charts/atlantis/templates/statefulset.yaml#L187C58-L187C82)), but you're referencing `securityContext` (as seen in [here](https://github.com/runatlantis/helm-charts/blob/7693bfd4a0f8505d5ea74cfcc27f4e02064074df/charts/atlantis/values.yaml#L571C1-L571C22))

I'm not sure it require a minor version bump as this is just a typo fix, schema was already correct.

## references

closes #392 

