### PR TITLE
Updated documentation for providing redis password for locking DB in values.yaml file

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -695,6 +695,7 @@ redis: {}
 #   insecureSkipVerify: false
 
 # -- When managing secrets outside the chart for the Redis secret, use this variable to reference the secret name.
+# Redis password (password: myRedisPassword) for the above redis configuration needs to be shared via this secret
 redisSecretName: ""
 
 # -- Set lifecycle hooks.


### PR DESCRIPTION
## what

<!--
- Redis connection password for locking DB will be provided via the secret and its referenced [here](https://github.com/runatlantis/helm-charts/blob/main/charts/atlantis/values.yaml#L698C1-L698C16).
-->


## why

<!--
- The documentation doesnt provide clear path on using the secret for providing the password
- So added a comment for future installs
-->


