### PR TITLE
feat: add dnsConfig to Atlantis

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.28.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.1.3
+version: 5.1.4
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.28.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.1.4
+version: 5.2.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -94,6 +94,7 @@ extraManifests:
 | disableApply | bool | `false` | Disables running `atlantis apply` regardless of which flags are sent with it. |
 | disableApplyAll | bool | `false` | Disables running `atlantis apply` without any flags. |
 | disableRepoLocking | bool | `false` | Stops atlantis locking projects and or workspaces when running terraform. |
+| dnsConfig | object | `{}` | Optionally specify dnsConfig for the Atlantis pod. Check values.yaml for examples. |
 | enableDiffMarkdownFormat | bool | `false` | Use Diff Markdown Format for color coding diffs. |
 | enableKubernetesBackend | bool | `false` | Optionally deploy rbac to allow for the serviceAccount to manage terraform state via the kubernetes backend. |
 | environment | object | `{}` | Environtment values to add to the Atlantis pod. Check values.yaml for examples. |

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -95,7 +95,7 @@ extraManifests:
 | disableApplyAll | bool | `false` | Disables running `atlantis apply` without any flags. |
 | disableRepoLocking | bool | `false` | Stops atlantis locking projects and or workspaces when running terraform. |
 | dnsConfig | object | `{}` | Optionally specify dnsConfig for the Atlantis pod. Check values.yaml for examples. |
-| dnsPolicy | string | `"None"` | Optionally specify dnsPolicy parameter to specify a DNS policy for a pod Check https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
+| dnsPolicy | string | `"ClusterFirst"` | Optionally specify dnsPolicy parameter to specify a DNS policy for a pod Check https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | enableDiffMarkdownFormat | bool | `false` | Use Diff Markdown Format for color coding diffs. |
 | enableKubernetesBackend | bool | `false` | Optionally deploy rbac to allow for the serviceAccount to manage terraform state via the kubernetes backend. |
 | environment | object | `{}` | Environtment values to add to the Atlantis pod. Check values.yaml for examples. |

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -95,6 +95,7 @@ extraManifests:
 | disableApplyAll | bool | `false` | Disables running `atlantis apply` without any flags. |
 | disableRepoLocking | bool | `false` | Stops atlantis locking projects and or workspaces when running terraform. |
 | dnsConfig | object | `{}` | Optionally specify dnsConfig for the Atlantis pod. Check values.yaml for examples. |
+| dnsPolicy | string | `"None"` | Optionally specify dnsPolicy parameter to specify a DNS policy for a pod Check https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | enableDiffMarkdownFormat | bool | `false` | Use Diff Markdown Format for color coding diffs. |
 | enableKubernetesBackend | bool | `false` | Optionally deploy rbac to allow for the serviceAccount to manage terraform state via the kubernetes backend. |
 | environment | object | `{}` | Environtment values to add to the Atlantis pod. Check values.yaml for examples. |

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -41,10 +41,13 @@ spec:
         {{- toYaml .Values.podTemplate.annotations | nindent 8 }}
         {{- end }}
     spec:
-      {{- if and .Values.dnsPolicy .Values.dnsConfig }}
+      {{- if and (or .Values.dnsPolicy (.Values.dnsPolicy and .Values.dnsConfig)) (ne .Values.dnsPolicy "ClusterFirst") }}
       dnsPolicy: {{ .Values.dnsPolicy}}
       {{- end }}
-      {{- if and .Values.dnsConfig (eq .Values.dnsPolicy "None") }}
+      {{- if or .Values.dnsConfig (eq .Values.dnsPolicy "None") }}
+      {{- if not .Values.dnsConfig }}
+      {{- fail "dnsPolicy is set to 'None', but dnsConfig is not provided" }}
+      {{- end }}
       dnsConfig:
         nameservers:
         {{- range .Values.dnsConfig.nameservers }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         {{- toYaml .Values.podTemplate.annotations | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.dnsPolicy }}
+      {{- if and .Values.dnsPolicy .Values.dnsConfig }}
       dnsPolicy: {{ .Values.dnsPolicy}}
       {{- end }}
       {{- if and .Values.dnsConfig (eq .Values.dnsPolicy "None") }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -41,7 +41,10 @@ spec:
         {{- toYaml .Values.podTemplate.annotations | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.dnsConfig }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy}}
+      {{- end }}
+      {{- if and .Values.dnsConfig (eq .Values.dnsPolicy "None") }}
       dnsConfig:
         nameservers:
         {{- range .Values.dnsConfig.nameservers }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -41,6 +41,19 @@ spec:
         {{- toYaml .Values.podTemplate.annotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+        nameservers:
+        {{- range .Values.dnsConfig.nameservers }}
+          - {{ . }}
+        {{- end }}
+        {{- if .Values.dnsConfig.searches }}
+        searches:
+        {{- range .Values.dnsConfig.searches }}
+          - {{ . }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
       {{- if .Values.hostAliases }}
       hostAliases:
         {{- range .Values.hostAliases }}

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1054,6 +1054,12 @@
       "type": "string",
       "default": "ClusterFirst",
       "description": "dnsPolicy for Atlantis pods",
+      "enum": [
+        "ClusterFirst",
+        "Default",
+        "ClusterFirstWithHostNet",
+        "None"
+      ],
       "examples": [
         "ClusterFirst",
         "Default",

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -584,7 +584,7 @@
       "type": [
         "integer",
         "null"
-        ],
+      ],
       "description": "Set terminationGracePeriodSeconds for the StatefulSet."
     },
     "ingress": {
@@ -1050,6 +1050,22 @@
         }
       ]
     },
+    "dnsConfig": {
+      "description": "Specify dnsConfig for Atlantis containers.",
+      "items": {
+        "$ref": "#/definitions/io.k8s.api.core.v1.DnsConfig"
+      },
+      "type": "object",
+      "default": [],
+      "examples": [
+        {
+          "nameservers": "8.8.8.8",
+          "searches": [
+            "mydomain.com"
+          ]
+        }
+      ]
+    },
     "hostNetwork": {
       "type": "boolean",
       "description": "Use the host's network namespace.",
@@ -1226,6 +1242,24 @@
         },
         "ip": {
           "description": "IP address of the host file entry.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.core.v1.DnsConfig": {
+      "description": "DnsConfig ",
+      "properties": {
+        "nameservers": {
+          "description": "a list of IP addresses that will be used as DNS servers for the search domain.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "searches": {
+          "description": "A list of DNS search domains for hostname lookup.",
           "type": "string"
         }
       },

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1050,6 +1050,17 @@
         }
       ]
     },
+    "dnsPolicy": {
+      "type": "string",
+      "default": "ClusterFirst",
+      "description": "dnsPolicy for Atlantis pods",
+      "examples": [
+        "ClusterFirst",
+        "Default",
+        "ClusterFirstWithHostNet",
+        "None"
+      ]
+    },
     "dnsConfig": {
       "description": "Specify dnsConfig for Atlantis containers.",
       "items": {

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -610,11 +610,11 @@ hostAliases: []
 
 # -- Optionally specify dnsPolicy parameter to specify a DNS policy for a pod
 # Check https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-dnsPolicy: ClusterFirst
+dnsPolicy: "ClusterFirst"
 
 # -- Optionally specify dnsConfig for the Atlantis pod.
 # Check values.yaml for examples.
-dnsConfig: {}
+#dnsConfig: {}
 #dnsConfig:
 #  nameservers:
 #    - 8.8.8.8

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -615,7 +615,7 @@ dnsPolicy: "ClusterFirst"
 # -- Optionally specify dnsConfig for the Atlantis pod.
 # Check values.yaml for examples.
 dnsConfig: {}
-#dnsConfig:
+# dnsConfig:
 #  nameservers:
 #    - 8.8.8.8
 #  searches:

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -610,7 +610,7 @@ hostAliases: []
 
 # -- Optionally specify dnsPolicy parameter to specify a DNS policy for a pod
 # Check https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-dnsPolicy: "ClusterFirst"
+dnsPolicy: "None"
 
 # -- Optionally specify dnsConfig for the Atlantis pod.
 # Check values.yaml for examples.

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -608,6 +608,10 @@ hostAliases: []
 #     - bbb.com
 #     ip: 10.0.0.2
 
+# -- Optionally specify dnsPolicy parameter to specify a DNS policy for a pod
+# Check https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+#dnsPolicy: "None"
+
 # -- Optionally specify dnsConfig for the Atlantis pod.
 # Check values.yaml for examples.
 dnsConfig: {}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -608,6 +608,15 @@ hostAliases: []
 #     - bbb.com
 #     ip: 10.0.0.2
 
+# -- Optionally specify dnsConfig for the Atlantis pod.
+# Check values.yaml for examples.
+dnsConfig: {}
+#dnsConfig:
+#  nameservers:
+#    - 8.8.8.8
+#  searches:
+#    - mydomain.com
+
 hostNetwork: false
 
 # - These annotations will be added to all the resources.

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -610,7 +610,7 @@ hostAliases: []
 
 # -- Optionally specify dnsPolicy parameter to specify a DNS policy for a pod
 # Check https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-dnsPolicy: "None"
+dnsPolicy: "ClusterFirst"
 
 # -- Optionally specify dnsConfig for the Atlantis pod.
 # Check values.yaml for examples.

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -614,7 +614,7 @@ dnsPolicy: "ClusterFirst"
 
 # -- Optionally specify dnsConfig for the Atlantis pod.
 # Check values.yaml for examples.
-#dnsConfig: {}
+dnsConfig: {}
 #dnsConfig:
 #  nameservers:
 #    - 8.8.8.8

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -610,7 +610,7 @@ hostAliases: []
 
 # -- Optionally specify dnsPolicy parameter to specify a DNS policy for a pod
 # Check https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-#dnsPolicy: "None"
+dnsPolicy: ClusterFirst
 
 # -- Optionally specify dnsConfig for the Atlantis pod.
 # Check values.yaml for examples.


### PR DESCRIPTION
## what
Adds dnsConfig property on Atlantis.


## why
Allows dns resolution for specific domains.

## tests
unit tests made successfully.
```
Installed plugin: unittest

### Chart [ atlantis ] ./charts/atlantis

 PASS  test pvc charts/atlantis/tests/pvc_test.yaml
 PASS  test secret-api for api secret   charts/atlantis/tests/secret-api_test.yaml
 PASS  test secret-aws for aws  charts/atlantis/tests/secret-aws_test.yaml
 PASS  test secret-basic-auth for git basic-auth secret charts/atlantis/tests/secret-basic-auth_test.yaml
 PASS  test secret-gitconfig for gitconfig      charts/atlantis/tests/secret-gitconfig_test.yaml
 PASS  test secret-netrc for netrc      charts/atlantis/tests/secret-netrc_test.yaml
 PASS  test secret-service-account for serviceAccountSecrets    charts/atlantis/tests/secret-service-account_test.yaml
 PASS  test secret-webhook for git webhook secret       charts/atlantis/tests/secret-webhook_test.yaml
 PASS  test service     charts/atlantis/tests/service_test.yaml
 PASS  test statefulset charts/atlantis/tests/statefulset_test.yaml
```

## references
- https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config

