### PR TITLE
Better handling of PATH env var with initConfig

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.28.3
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.2.2
+version: 5.3.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.28.3
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.2.1
+version: 5.2.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -105,6 +105,7 @@ extraManifests:
 | extraArgs | list | `[]` | Optionally specify extra arguments for the Atlantis pod. Check values.yaml for examples. |
 | extraContainers | list | `[]` | Optionally specify extra containers for the Atlantis pod. Check values.yaml for examples. |
 | extraManifests | list | `[]` | Optionally specify additional manifests to be created. Check values.yaml for examples. |
+| extraPath | string | `""` | Additional path (`:` separated) that will be appended to the system `PATH` environment variable. |
 | extraVolumeMounts | list | `[]` | Optionally specify additional volume mounts for the container. Check values.yaml for examples. |
 | extraVolumes | list | `[]` | Optionally specify additional volumes for the pod. Check values.yaml for examples. |
 | fullnameOverride | string | `""` | Provide a name to substitute for the full names of resources. |

--- a/charts/atlantis/templates/_helpers.tpl
+++ b/charts/atlantis/templates/_helpers.tpl
@@ -128,3 +128,16 @@ heritage: {{ .Release.Service }}
 {{ toYaml .Values.commonLabels }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Define PATH environment variable that will be used system-wide.
+*/}}
+{{- define "atlantis.pathEnvironmentVariable" -}}
+{{- if .Values.extraPath }}
+{{- printf "%s:" .Values.extraPath -}}
+{{- end -}}
+{{- if .Values.initConfig.sharedDir }}
+{{- printf "%s:" .Values.initConfig.sharedDir -}}
+{{- end -}}
+{{- printf "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" }}
+{{- end -}}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -252,8 +252,13 @@ spec:
           {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.environment }}
+          {{- if and ($.Values.initConfig.enabled) ($.Values.initConfig.sharedDir) (eq $key "PATH") }}
+          - name: PATH
+            value: {{ printf "%s:%s" $value $.Values.initConfig.sharedDir | quote}}
+          {{- else }}
           - name: {{ $key }}
             value: {{ $value | quote }}
+          {{- end }}
           {{- end }}
           {{- range .Values.environmentSecrets }}
           - name: {{ .name }}
@@ -485,8 +490,10 @@ spec:
             value: {{ .Values.aws.directory }}/config
           {{- end }}
           {{- if .Values.initConfig.enabled }}
+          {{- if not .Values.environment.PATH }}
           - name: PATH
             value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:{{ .Values.initConfig.sharedDir }}
+          {{- end }}
           - name: INIT_SHARED_DIR
             value: {{ .Values.initConfig.sharedDir }}
           {{- end }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -251,14 +251,11 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- end }}
-          {{- range $key, $value := .Values.environment }}
-          {{- if and ($.Values.initConfig.enabled) ($.Values.initConfig.sharedDir) (eq $key "PATH") }}
           - name: PATH
-            value: {{ printf "%s:%s" $value $.Values.initConfig.sharedDir | quote}}
-          {{- else }}
+            value: {{ template "atlantis.pathEnvironmentVariable" . }}
+          {{- range $key, $value := .Values.environment }}
           - name: {{ $key }}
             value: {{ $value | quote }}
-          {{- end }}
           {{- end }}
           {{- range .Values.environmentSecrets }}
           - name: {{ .name }}
@@ -490,10 +487,6 @@ spec:
             value: {{ .Values.aws.directory }}/config
           {{- end }}
           {{- if .Values.initConfig.enabled }}
-          {{- if not .Values.environment.PATH }}
-          - name: PATH
-            value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:{{ .Values.initConfig.sharedDir }}
-          {{- end }}
           - name: INIT_SHARED_DIR
             value: {{ .Values.initConfig.sharedDir }}
           {{- end }}

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -117,6 +117,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env
           value:
+            - name: PATH
+              value: /plugins:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
             - name: ATLANTIS_DATA_DIR
               value: /atlantis-data
             - name: ATLANTIS_REPO_ALLOWLIST
@@ -895,3 +897,58 @@ tests:
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
           value: 30
+  - it: extraPath
+    template: statefulset.yaml
+    set:
+      extraPath: "/foo:/bar"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: PATH
+              value: /foo:/bar:/plugins:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - name: ATLANTIS_DATA_DIR
+              value: /atlantis-data
+            - name: ATLANTIS_REPO_ALLOWLIST
+              value: <replace-me>
+            - name: ATLANTIS_PORT
+              value: "4141"
+            - name: ATLANTIS_ATLANTIS_URL
+              value: http://
+  - it: sharedDirPath
+    template: statefulset.yaml
+    set:
+      initConfig.sharedDir: "/home/atlantis"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: PATH
+              value: /home/atlantis:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - name: ATLANTIS_DATA_DIR
+              value: /atlantis-data
+            - name: ATLANTIS_REPO_ALLOWLIST
+              value: <replace-me>
+            - name: ATLANTIS_PORT
+              value: "4141"
+            - name: ATLANTIS_ATLANTIS_URL
+              value: http://
+  - it: extraPathWithSharedDirPath
+    template: statefulset.yaml
+    set:
+      initConfig.sharedDir: "/home/atlantis"
+      extraPath: "/foo:/bar"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: PATH
+              value: /foo:/bar:/home/atlantis:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - name: ATLANTIS_DATA_DIR
+              value: /atlantis-data
+            - name: ATLANTIS_REPO_ALLOWLIST
+              value: <replace-me>
+            - name: ATLANTIS_PORT
+              value: "4141"
+            - name: ATLANTIS_ATLANTIS_URL
+              value: http://

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -866,6 +866,10 @@
       "type": "string",
       "description": "Name of a Secret for Atlantis' HTTPS certificate containing the following data items `tls.crt` with the public certificate and `tls.key` with the private key."
     },
+    "extraPath": {
+      "type": "string",
+      "description": "Additional paths that will be appended to the system `PATH` environment variable. These paths should be separated with `:` to match system notation."
+    },
     "environment": {
       "type": "object",
       "description": "Map of environment variables for the container.",

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -470,6 +470,9 @@ enableKubernetesBackend: false
 # -- TLS Secret Name for Atlantis pod.
 tlsSecretName: ""
 
+# -- Additional path (`:` separated) that will be appended to the system `PATH` environment variable.
+extraPath: ""
+
 # -- Environtment values to add to the Atlantis pod.
 # Check values.yaml for examples.
 environment: {}


### PR DESCRIPTION
## what

We got a use-case where we need to defined the `PATH` environment variable through the `.Values.environment` [node](https://github.com/runatlantis/helm-charts/blob/e984db5a37cee1b1eecff8bb43702105fb8227a5/charts/atlantis/values.yaml#L475) for the statefulset, and we had some issues due to duplicate entries.
When `.Values.initConfig` is enabled, the chart actually add a [`PATH` environment variable](https://github.com/runatlantis/helm-charts/blob/e984db5a37cee1b1eecff8bb43702105fb8227a5/charts/atlantis/templates/statefulset.yaml#L488).
The issue is due to how Kubernetes handle duplicate envvars definition, when a referenced key is present in multiple resources, the value associated with the last source will override all previous values.
As `.Values.initConfig` variable is defined later in the manifest, it will always supersede previously definition, thus our `.Values.environment` node was bypassed.

This PR will add the following logic:
- if `.Values.initConfig.enabled` and no `PATH` in `.Values.environment`: add a `PATH` envvar like before
- if `.Values.initConfig.enabled` and `PATH` in `.Values.environment`: do not add a `PATH` envvar as it should use the one defined in `.Values.environment`

The rest of the logic is untouched.

## why

We wanted to be able to define more specifically how the `PATH` environment variable is presented to the statefulset avoiding any duplicate in the process.

## tests

- [X] I have tested my changes by created several values file for all possible combination regarding `PATH` and `initConfig` parameters

## references

- More information about precedence and duplicate env var management [[so](https://stackoverflow.com/questions/66288565/duplicated-env-variable-names-in-pod-definition-what-is-the-precedence-rule-to)]

