### PR TITLE
fix(helm-chart): script file name typo in init config

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.28.5
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.4.2
+version: 5.4.3
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -603,7 +603,7 @@ initConfig:
     echo "${TAC_SHA256_SUM}  terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64.tar.gz" | sha256sum -c
     tar xf "terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64.tar.gz"
     cp -fv "terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64/terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64" "${TAC_FILE}"
-    chmod 755 "${TG_FILE}"
+    chmod 755 "${TAC_FILE}"
     terragrunt-atlantis-config version
 
 # -- Optionally specify hostAliases for the Atlantis pod.


### PR DESCRIPTION
## what


- fixed file name typo in init config script for TAC file



## why

- it gives some errors while trying to update the version of those deps


## tests


- [ x ] I have tested my changes by ...


## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

