### PR TITLE
Allow setting externalTrafficPolicy on service

### DIFF
--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -179,6 +179,7 @@ extraManifests:
 | repoConfig | string | `""` | Use Server Side Repo Config, ref: https://www.runatlantis.io/docs/server-side-repo-config.html. Check values.yaml for examples. |
 | resources | object | `{}` | Resources for Atlantis. Check values.yaml for examples. |
 | service.annotations | object | `{}` |  |
+| service.externalTrafficPolicy | string | `nil` |  |
 | service.loadBalancerIP | string | `nil` |  |
 | service.loadBalancerSourceRanges | list | `[]` |  |
 | service.nodePort | string | `nil` |  |

--- a/charts/atlantis/templates/service.yaml
+++ b/charts/atlantis/templates/service.yaml
@@ -21,6 +21,9 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}

--- a/charts/atlantis/tests/service_test.yaml
+++ b/charts/atlantis/tests/service_test.yaml
@@ -27,6 +27,14 @@ tests:
               app: atlantis
               release: my-release
             type: NodePort
+  - it: externalTrafficPolicy
+    set:
+      service:
+        externalTrafficPolicy: Local
+    asserts:
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local
   - it: loadBalancerSourceRanges
     set:
       service:

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -514,6 +514,13 @@
           ],
           "default": 4141
         },
+        "externalTrafficPolicy": {
+          "description": "externalTrafficPolicy to set on service.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "loadBalancerIP": {
           "description": "IP address to assign to load balancer (if supported).",
           "type": [

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -290,6 +290,7 @@ service:
   targetPort: 4141
   loadBalancerIP: null
   loadBalancerSourceRanges: []
+  externalTrafficPolicy: null
 
 podTemplate:
   # -- Check values.yaml for examples.


### PR DESCRIPTION
## what

This PR allows setting the externalTrafficPolicy on service used by Atlantis. 


## why

I have noticed that some webhook requests flowing through a cloud load balancer, that has externalTrafficPolicy set to Cluster can fail with 504 error. After changing the value of externalTrafficPolicy to Local, the issue was resolved, as we have removed the extra hops between the LB and Atlantis pod. 

## tests

Tested locally + run the unit tests provided.

## references

https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip

