### PR TITLE
fix(chart): Allow setting portName on service

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.28.5
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.4.4
+version: 5.4.5
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -184,7 +184,7 @@ extraManifests:
 | service.loadBalancerSourceRanges | list | `[]` |  |
 | service.nodePort | string | `nil` |  |
 | service.port | int | `80` |  |
-| service.portName | string | `atlantis` |  |
+| service.portName | string | `"atlantis"` |  |
 | service.targetPort | int | `4141` |  |
 | service.type | string | `"NodePort"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations for the Service Account. Check values.yaml for examples. |

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -184,6 +184,7 @@ extraManifests:
 | service.loadBalancerSourceRanges | list | `[]` |  |
 | service.nodePort | string | `nil` |  |
 | service.port | int | `80` |  |
+| service.portName | string | `atlantis` |  |
 | service.targetPort | int | `4141` |  |
 | service.type | string | `"NodePort"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations for the Service Account. Check values.yaml for examples. |

--- a/charts/atlantis/templates/service.yaml
+++ b/charts/atlantis/templates/service.yaml
@@ -32,7 +32,7 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
     {{- end }}
       protocol: TCP
-      name: atlantis
+      name: {{ .Values.service.portName }}
   selector:
     app: {{ template "atlantis.name" . }}
     release: {{ .Release.Name }}

--- a/charts/atlantis/tests/service_test.yaml
+++ b/charts/atlantis/tests/service_test.yaml
@@ -35,6 +35,14 @@ tests:
       - equal:
           path: spec.externalTrafficPolicy
           value: Local
+  - it: portName
+    set:
+      service:
+        portName: http-atlantis
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: http-atlantis
   - it: loadBalancerSourceRanges
     set:
       service:

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -498,6 +498,13 @@
           ],
           "default": 80
         },
+        "portName": {
+          "description": "Port name to expose on the service.",
+          "type": [
+            "string"
+          ],
+          "default": "atlantis"
+        },
         "nodePort": {
           "description": "Port to expose on the node when the service type is NodePort.",
           "type": [

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -286,6 +286,7 @@ service:
   type: NodePort
   annotations: {}
   port: 80
+  portName: atlantis
   nodePort: null
   targetPort: 4141
   loadBalancerIP: null


### PR DESCRIPTION
## what

Allow setting portName field on service

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why

When using istio. there is a rule that sets the name of the service port. For this reason, we enable the portname setting.

<img width="433" alt="image" src="https://github.com/user-attachments/assets/f5bbd623-9357-41ea-be7c-5a4cc9b326ba">


<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests
local test
<!--
- [ ] I have tested my changes by ...
-->

## references

https://github.com/istio/istio/issues/11509

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

