### PR TITLE
chore(chart): bump initConfig script example versions

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.29.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.5.0
+version: 5.5.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -589,8 +589,8 @@ initConfig:
     set -eoux pipefail
 
     # example for terragrunt
-    TG_VERSION="v0.47.0"
-    TG_SHA256_SUM="98d45f6bfbfae84b51364c1ad6920f09ecb4d834908b0535e4e331a9fc6fc75b"
+    TG_VERSION="v0.67.5"
+    TG_SHA256_SUM="4e5ae67854a774be6419f7215733990b481662375dc0bd5f2eda05211a692cf0"
     TG_FILE="${INIT_SHARED_DIR}/terragrunt"
     wget https://github.com/gruntwork-io/terragrunt/releases/download/${TG_VERSION}/terragrunt_linux_amd64 -O "${TG_FILE}"
     echo "${TG_SHA256_SUM}  ${TG_FILE}" | sha256sum -c
@@ -598,13 +598,12 @@ initConfig:
     terragrunt -v
 
     # example for terragrunt-atlantis-config
-    TAC_VERSION="1.16.0" # without v
-    TAC_SHA256_SUM="fc3b069cf4ae51e9b7a7d01f09862d1974b260fffb3ec857d661d7b1756fe26f"
+    TAC_VERSION="1.18.0" # without v
+    TAC_SHA256_SUM="59178dcd3e426abf4b5d8fcb1ac8dbdea548a04aa64eaf39be200484a5e6f2ca"
     TAC_FILE="${INIT_SHARED_DIR}/terragrunt-atlantis-config"
-    wget "https://github.com/transcend-io/terragrunt-atlantis-config/releases/download/v${TAC_VERSION}/terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64.tar.gz"
-    echo "${TAC_SHA256_SUM}  terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64.tar.gz" | sha256sum -c
-    tar xf "terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64.tar.gz"
-    cp -fv "terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64/terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64" "${TAC_FILE}"
+    wget "https://github.com/transcend-io/terragrunt-atlantis-config/releases/download/v${TAC_VERSION}/terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64"
+    echo "${TAC_SHA256_SUM}  terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64" | sha256sum -c
+    cp -fv "terragrunt-atlantis-config_${TAC_VERSION}_linux_amd64" "${TAC_FILE}"
     chmod 755 "${TAC_FILE}"
     terragrunt-atlantis-config version
 


### PR DESCRIPTION
## what
- Updated the versions in the `initConfig` script for the examples of `terragrunt` and `terragrunt-atlantis-config`.
- Bumped the `terragrunt` version from `v0.47.0` to `v0.67.5` and the `terragrunt-atlantis-config` version from `1.16.0` to `1.18.0`.
- Adjusted the download commands and SHA256 checks for the new versions of the tools.

## why
- Keeping the versions of `terragrunt` and `terragrunt-atlantis-config` up to date ensures better security, performance, and compatibility.
- The new versions include bug fixes and improvements, which enhance the functionality of the `initConfig` example.
- It provides up-to-date examples for users who want to configure their Atlantis pods with these tools.

## tests
- [ ] Verified that the downloaded binaries match the provided SHA256 sums.
- [ ] Tested the script to ensure it correctly installs and configures `terragrunt` and `terragrunt-atlantis-config` in the init container.

## references
- N/A
