### PR TITLE
fix(templates): Fix and boolean on line 44 of statefulset.yaml

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.29.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.5.1
+version: 5.5.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -142,7 +142,7 @@ extraManifests:
 | initConfig.script | string | Check values.yaml. | Script to run on the init container. |
 | initConfig.sharedDir | string | `"/plugins"` | SharedDir is set as env var INIT_SHARED_DIR. |
 | initConfig.sharedDirReadOnly | bool | `true` |  |
-| initConfig.sizeLimit | string | `"100Mi"` | Size for the shared volume. |
+| initConfig.sizeLimit | string | `"300Mi"` | Size for the shared volume. |
 | initConfig.workDir | string | `"/tmp"` |  |
 | initContainers | list | `[]` | Optionally specify init containers manifests to be added to the Atlantis pod. Check values.yaml for examples. |
 | lifecycle | object | `{}` | Set lifecycle hooks. https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/. |

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         {{- toYaml .Values.podTemplate.annotations | nindent 8 }}
         {{- end }}
     spec:
-      {{- if and (or .Values.dnsPolicy (.Values.dnsPolicy and .Values.dnsConfig)) (ne .Values.dnsPolicy "ClusterFirst") }}
+      {{- if and (or .Values.dnsPolicy (and .Values.dnsPolicy .Values.dnsConfig)) (ne .Values.dnsPolicy "ClusterFirst") }}
       dnsPolicy: {{ .Values.dnsPolicy}}
       {{- end }}
       {{- if or .Values.dnsConfig (eq .Values.dnsPolicy "None") }}

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -579,7 +579,7 @@ initConfig:
   sharedDirReadOnly: true
   workDir: /tmp
   # -- Size for the shared volume.
-  sizeLimit: 100Mi
+  sizeLimit: 300Mi
   # -- Security context for the container.
   containerSecurityContext: {}
   # -- Script to run on the init container.


### PR DESCRIPTION
## what

Helm templating syntax requires that the boolean keyword goes before the two values that are being compared.
Example:
```
{{if and value1 value2}}
```
instead of
```
{{if value1 and value2}}
```


## why

This fixes the issue with respect to the following error when upgrading the helm chart:
```
Error: UPGRADE FAILED: template: atlantis/templates/statefulset.yaml:44:47: executing "atlantis/templates/statefulset.yaml" at <.Values.dnsPolicy>: dnsPolicy is not a method but has arguments
```

## tests

This fix has been tested locally and the manifests render out properly.

## references

closes #405 
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

