### PR TITLE
Fix(atlantis) Unable to use custom port #420

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.29.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.5.1
+version: 5.6.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -185,7 +185,7 @@ extraManifests:
 | service.nodePort | string | `nil` |  |
 | service.port | int | `80` |  |
 | service.portName | string | `"atlantis"` |  |
-| service.targetPort | int | `4141` |  |
+| service.targetPort | int | `4141` | [optional] Define the port you would like atlantis to run on. Defaults to 4141. |
 | service.type | string | `"NodePort"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations for the Service Account. Check values.yaml for examples. |
 | serviceAccount.create | bool | `true` | Specifies whether a ServiceAccount should be created. |

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -237,7 +237,7 @@ spec:
             {{- end }}
           ports:
           - name: atlantis
-            containerPort: 4141
+            containerPort: {{ .Values.service.targetPort }}
           {{- with .Values.lifecycle }}
           lifecycle: {{ toYaml . | nindent 12 }}
           {{- end }}
@@ -326,7 +326,7 @@ spec:
             value: {{ .Values.orgWhitelist | quote }}
             {{- end }}
           - name: ATLANTIS_PORT
-            value: "4141"
+            value: {{ .Values.service.targetPort | quote }}
           {{- if .Values.repoConfig }}
           - name: ATLANTIS_REPO_CONFIG
             value: /etc/atlantis/repos.yaml
@@ -505,7 +505,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 4141
+              port: {{ .Values.service.targetPort }}
               scheme: {{ .Values.livenessProbe.scheme }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -517,7 +517,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 4141
+              port: {{ .Values.service.targetPort }}
               scheme: {{ .Values.readinessProbe.scheme }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -168,6 +168,54 @@ tests:
           path: spec.template.spec.updateStrategy
       - notExists:
           path: spec.volumeClaimTemplates
+  - it: custom port values
+    template: statefulset.yaml
+    set:
+      service:
+        targetPort: 8888
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+            - containerPort: 8888
+              name: atlantis
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: PATH
+              value: /plugins:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - name: ATLANTIS_DATA_DIR
+              value: /atlantis-data
+            - name: ATLANTIS_REPO_ALLOWLIST
+              value: <replace-me>
+            - name: ATLANTIS_PORT
+              value: "8888"
+            - name: ATLANTIS_ATLANTIS_URL
+              value: http://
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 8888
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 60
+            successThreshold: 1
+            timeoutSeconds: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 8888
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 60
+            successThreshold: 1
+            timeoutSeconds: 5
   - it: replicaCount
     template: statefulset.yaml
     set:

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -288,6 +288,7 @@ service:
   port: 80
   portName: atlantis
   nodePort: null
+  # -- (int) [optional] Define the port you would like atlantis to run on. Defaults to 4141.
   targetPort: 4141
   loadBalancerIP: null
   loadBalancerSourceRanges: []


### PR DESCRIPTION
## what

- Provide ability to use the `service.TargetPort` key to define alternative ports for running atlantis.
- Extended documentation for the `targetPort` key to include implications.


## why

- There is partial support for custom ports, but it is not extended to include all port related configurations. This allows for a hollistic approach to custom ports.

## tests

Ive extended the helm tests to cover this use-case.

## references

`closes #420 `

