### PR TITLE
feat: OpenTofu support to helm chart

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 # renovate: datasource=docker depName=ghcr.io/runatlantis/atlantis
-appVersion: v0.29.0
+appVersion: v0.30.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
 version: 5.5.2

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -91,6 +91,7 @@ extraManifests:
 | customPem | string | `""` | Allows to override the /etc/ssl/certs/ca-certificates.cer with your custom one. You have to create a secret with the specified name. |
 | dataStorage | string | `""` | DEPRECATED - Disk space available to check out repositories. Example: 5Gi. |
 | defaultTFVersion | string | `""` | Sets the default terraform version to be used in atlantis server. Check values.yaml for examples. |
+| defaultTFVersion | string | `terraform` | Sets the default distribution to be used in atlantis server. Check values.yaml for examples. |
 | disableApply | bool | `false` | Disables running `atlantis apply` regardless of which flags are sent with it. |
 | disableApplyAll | bool | `false` | Disables running `atlantis apply` without any flags. |
 | disableRepoLocking | bool | `false` | Stops atlantis locking projects and or workspaces when running terraform. |

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -307,6 +307,10 @@ spec:
           - name: ATLANTIS_DEFAULT_TF_VERSION
             value: {{ .Values.defaultTFVersion }}
           {{- end }}
+          {{- if .Values.defaultTFDistribution }}
+          - name: ATLANTIS_TF_DISTRIBUTION
+            value: {{ .Values.defaultTFDistribution }}
+          {{- end }}
           {{- if .Values.logLevel }}
           - name: ATLANTIS_LOG_LEVEL
             value: {{ .Values.logLevel | quote}}

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -313,6 +313,10 @@
       "type": "string",
       "description": "Default Terraform version to be used by atlantis server"
     },
+    "defaultTFDistribution": {
+      "type": "string",
+      "description": "Default Atlantis distribution to be used by atlantis server. Either Opentufu or terraform"
+    },
     "disableApply": {
       "type": "boolean",
       "description": "Disables running `atlantis apply` regardless of what options are specified",

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -228,6 +228,9 @@ hideUnchangedPlanComments: false
 defaultTFVersion: ""
 # Example: "0.12.0".
 
+### -- Sets which TF distribution to use. Can be set to terraform or opentofu.
+defaultTFDistribution: terraform
+
 # -- Disables running `atlantis apply` regardless of which flags are sent with it.
 disableApply: false
 
@@ -239,6 +242,7 @@ disableRepoLocking: false
 
 # -- Use Diff Markdown Format for color coding diffs.
 enableDiffMarkdownFormat: false
+
 
 # -- Optionally specify an username and a password for basic authentication.
 basicAuth:


### PR DESCRIPTION
## what

Upgrade Atlantis to the latest version `v0.30.0` that adds support to Opentufu





## references
 closes #429 


