### PR TITLE
feat: add metricRelabelings support to ServiceMonitor

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.30.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.7.0
+version: 5.8.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -201,6 +201,7 @@ extraManifests:
 | servicemonitor.auth.externalSecret.name | string | `""` |  |
 | servicemonitor.enabled | bool | `false` | To enable a Prometheus servicemonitor, set enabled to true,   and enable the metrics in this file's repoConfig   by setting a value for metrics.prometheus.endpoint. |
 | servicemonitor.interval | string | `"30s"` |  |
+| servicemonitor.metricRelabelings | list | `[]` | Optional metric relabelings to drop or modify metrics. |
 | servicemonitor.path | string | `"/metrics"` |  |
 | statefulSet.annotations | object | `{}` |  |
 | statefulSet.labels | object | `{}` |  |

--- a/charts/atlantis/templates/servicemonitor.yaml
+++ b/charts/atlantis/templates/servicemonitor.yaml
@@ -28,6 +28,10 @@ spec:
   - port: atlantis
     interval: {{ .Values.servicemonitor.interval }}
     path: {{ .Values.servicemonitor.path }}
+    {{- with .Values.servicemonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- if .Values.servicemonitor.auth.basicAuth.enabled }}
     basicAuth:
       username:

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1217,6 +1217,12 @@
               }
             }
           }
+        },
+        "metricRelabelings": {
+          "description": "Optional metric relabelings to drop or modify metrics.",
+          "items": {},
+          "type": "array",
+          "default": []
         }
       }
     },

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -700,6 +700,12 @@ servicemonitor:
       # keys:
       #   username: USERNAME
       #   password: ATLANTIS_WEB_PASSWORD
+  # -- Optional metric relabelings to drop or modify metrics.
+  metricRelabelings: []
+  # metricRelabelings:
+  #   - action: drop
+  #     regex: "atlantis_project_apply_execution_.*"
+  #     sourceLabels: [__name__]
 
 # -- Enable this if you're using Google Managed Prometheus.
 podMonitor:


### PR DESCRIPTION
## what

- Adds metricRelabelings value under ServiceMonitor to allow customization of the ingested metrics/labels. See Prometheus Operator for more info - https://github.com/prometheus-operator/prometheus-operator/blob/d2599cfe67beb97b9208e79422457b0f7cde3c4a/Documentation/api.md#endpoint

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why

- Prevents potential cardinality issues, allows user control over metric ingestion spend

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests

- diff output of enabled ServiceMonitor with/without new value

```
--- 219,229 ----
    - port: atlantis
      interval: 30s
      path: /metrics
+     metricRelabelings:
+       - action: drop
+         regex: atlantis_project_apply_execution_.*
+         sourceLabels:
+         - __name__
```

- ran `make unit-test-run-atlantis`

```
### Chart [ atlantis ] ./charts/atlantis

 PASS  test configmap-gitconfig-init for gitconfig	charts/atlantis/tests/configmap-gitconfig-init_test.yaml
 PASS  test pvc	charts/atlantis/tests/pvc_test.yaml
 PASS  test secret-api for api secret	charts/atlantis/tests/secret-api_test.yaml
 PASS  test secret-aws for aws	charts/atlantis/tests/secret-aws_test.yaml
 PASS  test secret-basic-auth for git basic-auth secret	charts/atlantis/tests/secret-basic-auth_test.yaml
 PASS  test secret-gitconfig for gitconfig	charts/atlantis/tests/secret-gitconfig_test.yaml
 PASS  test secret-netrc for netrc	charts/atlantis/tests/secret-netrc_test.yaml
 PASS  test secret-service-account for serviceAccountSecrets	charts/atlantis/tests/secret-service-account_test.yaml
 PASS  test secret-webhook for git webhook secret	charts/atlantis/tests/secret-webhook_test.yaml
 PASS  test service	charts/atlantis/tests/service_test.yaml
 PASS  test statefulset	charts/atlantis/tests/statefulset_test.yaml

Charts:      1 passed, 1 total
Test Suites: 11 passed, 11 total
Tests:       93 passed, 93 total
Snapshot:    0 passed, 0 total
Time:        672.058375ms
```

<!--
- [ ] I have tested my changes by ...
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

