### PR TITLE
Redis Secret Password Key

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.30.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.8.0
+version: 5.9.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -176,6 +176,7 @@ extraManifests:
 | readinessProbe.timeoutSeconds | int | `5` |  |
 | redis | object | `{}` | Configure Redis Locking DB. lockingDbType value must be redis for the config to take effect. Check values.yaml for examples. |
 | redisSecretName | string | `""` | When managing secrets outside the chart for the Redis secret, use this variable to reference the secret name. |
+| redisSecretPasswordKey | string | `""` | Key within the existing Redis secret that contains the password value. |
 | replicaCount | int | `1` | Replica count for Atlantis pods. |
 | repoConfig | string | `""` | Use Server Side Repo Config, ref: https://www.runatlantis.io/docs/server-side-repo-config.html. Check values.yaml for examples. |
 | resources | object | `{}` | Resources for Atlantis. Check values.yaml for examples. |

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -176,7 +176,7 @@ extraManifests:
 | readinessProbe.timeoutSeconds | int | `5` |  |
 | redis | object | `{}` | Configure Redis Locking DB. lockingDbType value must be redis for the config to take effect. Check values.yaml for examples. |
 | redisSecretName | string | `""` | When managing secrets outside the chart for the Redis secret, use this variable to reference the secret name. |
-| redisSecretPasswordKey | string | `""` | Key within the existing Redis secret that contains the password value. |
+| redisSecretPasswordKey | string | `"password"` | Key within the existing Redis secret that contains the password value. |
 | replicaCount | int | `1` | Replica count for Atlantis pods. |
 | repoConfig | string | `""` | Use Server Side Repo Config, ref: https://www.runatlantis.io/docs/server-side-repo-config.html. Check values.yaml for examples. |
 | resources | object | `{}` | Resources for Atlantis. Check values.yaml for examples. |

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -477,7 +477,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ template "atlantis.redisSecretName" . }}
-                key: password
+                key: {{ .Values.redisSecretPasswordKey | quote }}
           {{- end }}
           {{- if .Values.redis.port }}
           - name: ATLANTIS_REDIS_PORT

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -825,6 +825,96 @@ tests:
               secretKeyRef:
                 key: apisecret
                 name: atlantis-api
+  - it: redisHost
+    template: statefulset.yaml
+    set:
+      redis.host: my-redis
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_REDIS_HOST
+            value: my-redis
+  - it: redisPassword
+    template: statefulset.yaml
+    set:
+      redis.password: SuperSecretPassword
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: atlantis-redis
+                key: password
+  - it: redisSecretName
+    template: statefulset.yaml
+    set:
+      redisSecretName: existing-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: existing-secret
+                key: password
+  - it: redisSecretPasswordKey
+    template: statefulset.yaml
+    set:
+      redisSecretName: my-secret
+      redisSecretPasswordKey: my-password-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: my-password-key
+  - it: redisPort
+    template: statefulset.yaml
+    set:
+      redis.port: 1234
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_REDIS_PORT
+            value: "1234"
+  - it: redisDb
+    template: statefulset.yaml
+    set:
+      redis.db: 1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_REDIS_DB
+            value: "1"
+  - it: redisTlsEnabled
+    template: statefulset.yaml
+    set:
+      redis.tlsEnabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_REDIS_TLS_ENABLED
+            value: "true"
+  - it: redisInsecureSkipVerify
+    template: statefulset.yaml
+    set:
+      redis.insecureSkipVerify: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_REDIS_INSECURE_SKIP_VERIFY
+            value: "true"
   - it: command
     template: statefulset.yaml
     set:

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -846,7 +846,7 @@ tests:
             name: ATLANTIS_REDIS_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: atlantis-redis
+                name: my-release-atlantis-redis
                 key: password
   - it: redisSecretName
     template: statefulset.yaml

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1283,7 +1283,11 @@
     },
     "redisSecretName": {
       "type": "string",
-      "description": "Name of a pre-existing Kubernetes `Secret` containing a `password` key. Use this instead of `redis.password`."
+      "description": "Name of a pre-existing Kubernetes `Secret` containing the password for Redis. Use this instead of `redis.password`."
+    },
+    "redisSecretPasswordKey": {
+      "type": "string",
+      "description": "Key within the existing Redis `Secret` that contains the password value."
     },
     "lifecycle": {
       "type": "object",

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -732,7 +732,7 @@ redis: {}
 redisSecretName: ""
 
 # -- Key within the existing Redis secret that contains the password value.
-redisSecretPasswordKey: "password"
+redisSecretPasswordKey: password
 
 # -- Set lifecycle hooks.
 # https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/.

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -731,6 +731,9 @@ redis: {}
 # -- When managing secrets outside the chart for the Redis secret, use this variable to reference the secret name.
 redisSecretName: ""
 
+# -- Key within the existing Redis secret that contains the password value.
+redisSecretPasswordKey: "password"
+
 # -- Set lifecycle hooks.
 # https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/.
 lifecycle: {}


### PR DESCRIPTION
## what

- Added `redisSecretPasswordKey` value
- Kept previous `password` value as default for backward-compatibility


## why

This allows users to override the default `password` key used when specifying an existing `Secret` for Redis. This makes for a more seamless integration with popular third-party Redis Helm charts.

For example, the Bitnami Redis chart creates a secret called `<release>-redis` with a key called `redis-password` whose value is the password generated for that Redis distribution. Allowing users to specify an arbitrary key name means they can seamlessly integrate that Redis chart with this Atlantis chart and use the same secret.

## tests

I have tested this successfully in an Amazon EKS cluster.

## references

N/A

