### PR TITLE
fix(chart): explicitly set namespace based on release

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.30.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.9.0
+version: 5.9.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/configmap-config.yaml
+++ b/charts/atlantis/templates/configmap-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "atlantis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/configmap-gitconfig-init.yaml
+++ b/charts/atlantis/templates/configmap-gitconfig-init.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "atlantis.fullname" . }}-gitconfig-init
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/configmap-init-config.yaml
+++ b/charts/atlantis/templates/configmap-init-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "atlantis.fullname" . }}-init-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/configmap-repo-config.yaml
+++ b/charts/atlantis/templates/configmap-repo-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "atlantis.fullname" . }}-repo-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -18,6 +18,7 @@ apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
     {{- if .Values.ingress.labels }}

--- a/charts/atlantis/templates/podmonitor.yaml
+++ b/charts/atlantis/templates/podmonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.googleapis.com/v1
 kind: PodMonitoring
 metadata:
   name: {{ template "atlantis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- if or .Values.service.annotations .Values.extraAnnotations }}

--- a/charts/atlantis/templates/pvc.yaml
+++ b/charts/atlantis/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "atlantis.fullname" . }}-data
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/role.yaml
+++ b/charts/atlantis/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "atlantis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/rolebinding.yaml
+++ b/charts/atlantis/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "atlantis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/secret-api.yaml
+++ b/charts/atlantis/templates/secret-api.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "atlantis.apiSecretName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/secret-aws.yaml
+++ b/charts/atlantis/templates/secret-aws.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "atlantis.fullname" . }}-aws
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/secret-basic-auth.yaml
+++ b/charts/atlantis/templates/secret-basic-auth.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "atlantis.fullname" . }}-basic-auth
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/secret-gitconfig.yaml
+++ b/charts/atlantis/templates/secret-gitconfig.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "atlantis.fullname" . }}-gitconfig
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/secret-netrc.yaml
+++ b/charts/atlantis/templates/secret-netrc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "atlantis.fullname" . }}-netrc
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/secret-redis.yaml
+++ b/charts/atlantis/templates/secret-redis.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "atlantis.fullname" . }}-redis
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/secret-service-account.yaml
+++ b/charts/atlantis/templates/secret-service-account.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $name }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     component: service-account-secret
     {{- include "atlantis.labels" $ | nindent 4 }}

--- a/charts/atlantis/templates/secret-webhook.yaml
+++ b/charts/atlantis/templates/secret-webhook.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "atlantis.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- with .Values.extraAnnotations }}

--- a/charts/atlantis/templates/service.yaml
+++ b/charts/atlantis/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "atlantis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- if or .Values.service.annotations .Values.extraAnnotations }}

--- a/charts/atlantis/templates/serviceaccount.yaml
+++ b/charts/atlantis/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "atlantis.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.extraAnnotations }}

--- a/charts/atlantis/templates/servicemonitor.yaml
+++ b/charts/atlantis/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "atlantis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
     {{- with .Values.servicemonitor.additionalLabels }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "atlantis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
     {{- with .Values.statefulSet.labels }}

--- a/charts/atlantis/templates/tests/test-atlantis-configmap.yaml
+++ b/charts/atlantis/templates/tests/test-atlantis-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "atlantis.fullname" . }}-tests
+  namespace: {{ .Release.Namespace }}
 data:
   tests.bats: |-
     setup() {

--- a/charts/atlantis/templates/tests/test-atlantis-pod.yaml
+++ b/charts/atlantis/templates/tests/test-atlantis-pod.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Release.Name }}-ui-test"
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: test
     {{- with .Values.test.annotations }}

--- a/charts/atlantis/templates/webhook-ingress.yaml
+++ b/charts/atlantis/templates/webhook-ingress.yaml
@@ -18,6 +18,7 @@ apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}-secondary
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlantis.labels" . | nindent 4 }}
     {{- with .Values.webhook_ingress.labels }}

--- a/charts/atlantis/tests/misc_test.yaml
+++ b/charts/atlantis/tests/misc_test.yaml
@@ -1,0 +1,47 @@
+suite: test miscellaneous cases
+templates:
+  - "*.yaml"
+chart:
+  appVersion: test-appVersion
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: ensure namespaces are specified in all resources
+    set:
+      config: "dummy"
+      gitconfigReadOnly: false
+      gitconfig: "dummy"
+      initConfig:
+        enabled: true
+      repoConfig: "dummy"
+      podMonitor:
+        enabled: true
+      servicemonitor:
+        enabled: true
+      enableKubernetesBackend: true
+      api:
+        secret: "dummy"
+      aws:
+        config: "dummy"
+      basicAuth:
+        username: "dummy"
+        password: "dummy"
+      netrc: "dummy"
+      redis:
+        password: "dummy"
+      serviceAccountSecrets:
+        credentials: "dummy"
+      webhook_ingress:
+        enabled: true
+      extraManifests:
+      - apiVersion: v1
+        kind: Pod
+        metadata:
+          name: dummy
+          namespace: "my-namespace"
+
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-namespace


### PR DESCRIPTION
On `helm install` or `upgrade`, the `--namespace` flag is respected regardless. 
However, when using this chart for static templating, the`--namespace` flag is ignored because the templates do not explicitly set `.metadata.namespace` to `.Release.Namespace`, making it cumbersome to customize the namespace.
