### PR TITLE
Add support for Gitea

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.30.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.9.1
+version: 5.10.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -43,6 +43,7 @@ In order for Atlantis to start and run successfully:
 
 1. At least one of the following sets of credentials must be defined:
     - `github`
+    - `gitea`
     - `gitlab`
     - `bitbucket`
     - `azuredevops`
@@ -113,6 +114,7 @@ extraManifests:
 | gitconfig | string | `""` | When referencing Terraform modules in private repositories, it may be helpful (necessary?) to use redirection in a .gitconfig. Check values.yaml for examples. |
 | gitconfigReadOnly | bool | `true` | When true gitconfig file is mounted as read only. When false, the gitconfig value will be copied to '/home/atlantis/.gitconfig' before starting the atlantis process, instead of being mounted as a file. |
 | gitconfigSecretName | string | `""` | If managing secrets outside the chart for the gitconfig, use this variable to reference the secret name |
+| gitea | object | `{}` | If using Gitea, please enter your values as follows. The 'baseUrl' key is exclusive to self-hosted Gitea installations. The chart will perform the base64 encoding for you for values that are stored in secrets. Check values.yaml for examples. |
 | github | object | `{}` | If using GitHub, please enter your values as follows. The chart will perform the base64 encoding for values that are stored in secrets. The 'hostname' key is exclusive to GitHub Enterprise installations. Check values.yaml for examples. |
 | githubApp | object | `{}` | If using a GitHub App, please enter your values as follows. The chart will perform the base64 encoding for you for values that are stored in secrets. installationId is necessary when there are multiple installs of the Github App. Check values.yaml for examples. |
 | gitlab | object | `{}` | If using GitLab, please enter your values as follows. The 'hostname' key is exclusive to GitLab Enterprise installations. The chart will perform the base64 encoding for you for values that are stored in secrets. Check values.yaml for examples. |

--- a/charts/atlantis/README.md.gotmpl
+++ b/charts/atlantis/README.md.gotmpl
@@ -36,6 +36,7 @@ In order for Atlantis to start and run successfully:
 
 1. At least one of the following sets of credentials must be defined:
     - `github`
+    - `gitea`
     - `gitlab`
     - `bitbucket`
     - `azuredevops`

--- a/charts/atlantis/templates/NOTES.txt
+++ b/charts/atlantis/templates/NOTES.txt
@@ -20,5 +20,6 @@
 2. Atlantis will not start successfully unless at least one of the following sets of credentials are specified (see values.yaml for detailed usage):
   - github
   - githubApp
+  - gitea
   - gitlab
   - bitbucket

--- a/charts/atlantis/templates/secret-webhook.yaml
+++ b/charts/atlantis/templates/secret-webhook.yaml
@@ -19,6 +19,10 @@ data:
   github_token: {{ required "github.token is required if github configuration is specified." .Values.github.token | b64enc }}
   github_secret: {{ required "github.secret is required if github configuration is specified." .Values.github.secret | b64enc }}
   {{- end }}
+  {{- if .Values.gitea }}
+  gitea_token: {{ required "gitea.token is required if gitea configuration is specified." .Values.gitea.token | b64enc }}
+  gitea_secret: {{ required "gitea.secret is required if gitea configuration is specified." .Values.gitea.secret | b64enc }}
+  {{- end }}
   {{- if .Values.gitlab }}
   gitlab_token: {{ required "gitlab.token is required if gitlab configuration is specified." .Values.gitlab.token | b64enc }}
   gitlab_secret: {{ required "gitlab.secret is required if gitlab configuration is specified." .Values.gitlab.secret | b64enc }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -392,6 +392,24 @@ spec:
             value: "/var/github-app/key.pem"
           {{- end }}
           {{- end }}
+          {{- if .Values.gitea }}
+          - name: ATLANTIS_GITEA_USER
+            value: {{ required "gitea.user is required if gitea configuration is specified." .Values.gitea.user }}
+          - name: ATLANTIS_GITEA_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "atlantis.vcsSecretName" . }}
+                key: gitea_token
+          - name: ATLANTIS_GITEA_WEBHOOK_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "atlantis.vcsSecretName" . }}
+                key: gitea_secret
+          {{- if .Values.gitea.baseUrl }}
+          - name: ATLANTIS_GITEA_BASE_URL
+            value: {{ .Values.gitea.baseUrl }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.gitlab }}
           - name: ATLANTIS_GITLAB_USER
             value: {{ required "gitlab.user is required if gitlab configuration is specified." .Values.gitlab.user }}

--- a/charts/atlantis/tests/secret-webhook_test.yaml
+++ b/charts/atlantis/tests/secret-webhook_test.yaml
@@ -82,6 +82,33 @@ tests:
           value:
             github_secret: YmF6
             github_token: YmFy
+  - it: gitea only user set
+    set:
+      gitea:
+        user: foo
+    asserts:
+      - failedTemplate:
+          errorMessage: gitea.token is required if gitea configuration is specified.
+  - it: gitea only user and token are set
+    set:
+      gitea:
+        user: foo
+        token: bar
+    asserts:
+      - failedTemplate:
+          errorMessage: gitea.secret is required if gitea configuration is specified.
+  - it: gitea
+    set:
+      gitea:
+        user: foo
+        token: bar
+        secret: baz
+    asserts:
+      - equal:
+          path: data
+          value:
+            gitea_secret: YmF6
+            gitea_token: YmFy
   - it: gitlab only user set
     set:
       gitlab:

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -639,6 +639,35 @@ tests:
           content:
             name: ATLANTIS_GH_APP_KEY_FILE
             value: /var/github-app/key.pem
+  - it: gitea
+    template: statefulset.yaml
+    set:
+      gitea:
+        user: foo
+        token: bar
+        secret: baz
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_GITEA_USER
+            value: foo
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_GITEA_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: gitea_token
+                name: my-release-atlantis-webhook
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_GITEA_WEBHOOK_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: gitea_secret
+                name: my-release-atlantis-webhook
   - it: gitlab
     template: statefulset.yaml
     set:

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -113,6 +113,29 @@
       },
       "additionalProperties": false
     },
+    "gitea": {
+      "type": "object",
+      "description": "Gitea settings",
+      "properties": {
+        "user": {
+          "type": "string",
+          "description": "Name of the Atlantis Gitea user."
+        },
+        "token": {
+          "type": "string",
+          "description": "Access token of the Atlantis Gitea user."
+        },
+        "secret": {
+          "type": "string",
+          "description": "Webhook secret for the Atlantis Gitea integration. All repositories in Gitea that are to be integrated with Atlantis must share the same value."
+        },
+        "baseUrl": {
+          "type": "string",
+          "description": "Base URL of your Gitea installation."
+        }
+      },
+      "additionalProperties": false
+    },
     "gitlab": {
       "type": "object",
       "description": "GitLab settings",

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -50,6 +50,17 @@ githubApp: {}
 #     -----END PRIVATE KEY-----
 #   secret: baz
 
+# -- If using Gitea, please enter your values as follows.
+# The 'baseUrl' key is exclusive to self-hosted Gitea installations.
+# The chart will perform the base64 encoding for you for values that are stored in secrets.
+# Check values.yaml for examples.
+gitea: {}
+# gitea:
+#   user: foo
+#   token: bar
+#   secret: baz
+#   baseUrl: gitea.your.org
+
 # -- If using GitLab, please enter your values as follows.
 # The 'hostname' key is exclusive to GitLab Enterprise installations.
 # The chart will perform the base64 encoding for you for values that are stored in secrets.


### PR DESCRIPTION
## what

Add support for Gitea.

## why

It's clearly in the scope of this project.

## tests

I have successfully deployed an Atlantis instance using this feature.

## references

Replaces https://github.com/runatlantis/helm-charts/pull/416
Closes https://github.com/runatlantis/helm-charts/issues/403
