### PR TITLE
feat(pvc fields): claim exsisting pvc

### DIFF
--- a/charts/atlantis/templates/pvc.yaml
+++ b/charts/atlantis/templates/pvc.yaml
@@ -21,6 +21,8 @@ spec:
   accessModes: {{ .Values.volumeClaim.accessModes | toYaml | nindent 2 }}
   resources:
     requests:
+      # The biggest thing Atlantis stores is the Git repo when it checks it out.
+      # It deletes the repo after the pull request is merged.
       storage: {{ .Values.volumeClaim.dataStorage }}
   {{- if .Values.volumeClaim.storageClassName }}
   storageClassName: {{ .Values.volumeClaim.storageClassName }}

--- a/charts/atlantis/templates/pvc.yaml
+++ b/charts/atlantis/templates/pvc.yaml
@@ -1,4 +1,11 @@
 {{- if and .Values.volumeClaim.enabled ( not .Values.dataStorage ) }}
+{{- if .Values.volumeClaim.existingClaim }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.volumeClaim.existingClaim }}
+  namespace: {{ .Release.Namespace }}
+{{- else }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -11,13 +18,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  accessModes: {{ .Values.volumeClaim.accessModes| toYaml | nindent 2 }}
+  accessModes: {{ .Values.volumeClaim.accessModes | toYaml | nindent 2 }}
   resources:
     requests:
-      # The biggest thing Atlantis stores is the Git repo when it checks it out.
-      # It deletes the repo after the pull request is merged.
       storage: {{ .Values.volumeClaim.dataStorage }}
   {{- if .Values.volumeClaim.storageClassName }}
   storageClassName: {{ .Values.volumeClaim.storageClassName }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## what
persistentvolumeclaim specs is immutable after creation

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->


## why
failing to replace objects on pvc ex error mesage below
```yaml
failed to replace object: PersistentVolumeClaim "atlantis-data" is invalid: spec: Forbidden: spec is immutable after creation except resources.requests and volumeAttributesClassName for bound claims
│   core.PersistentVolumeClaimSpec{
│       AccessModes:      {"ReadWriteOnce"},
│       Selector:         nil,
│       Resources:        {Requests: {s"storage": {i: {...}, s: "50Gi", Format: "BinarySI"}}},
│ -     VolumeName:       "my-pvc-id",
│ +     VolumeName:       "",
│ -     StorageClassName: &"default",
│ +     StorageClassName: nil,
│       VolumeMode:       &"Filesystem",
│       DataSource:       nil,
│       ... // 2 identical fields
│   }
``` 

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## tests
- [X] Unit test only...
- [ ] To be tested on my cluster, not yet done...
<!--
- [ ] I have tested my changes by ...
-->

## references

- Possibly fixes #438 

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->