### PR TITLE
Use stringData instead of data for secrets

### DIFF
--- a/charts/atlantis/templates/secret-api.yaml
+++ b/charts/atlantis/templates/secret-api.yaml
@@ -10,6 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data:
-  apisecret: {{ .Values.api.secret | b64enc }}
+stringData:
+  apisecret: {{ .Values.api.secret }}
 {{- end }}

--- a/charts/atlantis/templates/secret-aws.yaml
+++ b/charts/atlantis/templates/secret-aws.yaml
@@ -10,11 +10,11 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data:
+stringData:
   {{- if .Values.aws.credentials }}
-  credentials: {{ .Values.aws.credentials | b64enc }}
+  credentials: {{ .Values.aws.credentials }}
   {{- end }}
   {{- if .Values.aws.config }}
-  config: {{ .Values.aws.config | b64enc }}
+  config: {{ .Values.aws.config }}
   {{- end }}
 {{- end }}

--- a/charts/atlantis/templates/secret-basic-auth.yaml
+++ b/charts/atlantis/templates/secret-basic-auth.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data:
-  username: {{ .Values.basicAuth.username | b64enc }}
-  password: {{ .Values.basicAuth.password | b64enc }}
+stringData:
+  username: {{ .Values.basicAuth.username }}
+  password: {{ .Values.basicAuth.password }}
 {{- end }}

--- a/charts/atlantis/templates/secret-gitconfig.yaml
+++ b/charts/atlantis/templates/secret-gitconfig.yaml
@@ -10,6 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data:
-  gitconfig: {{ .Values.gitconfig | b64enc }}
+stringData:
+  gitconfig: {{ .Values.gitconfig }}
 {{- end }}

--- a/charts/atlantis/templates/secret-netrc.yaml
+++ b/charts/atlantis/templates/secret-netrc.yaml
@@ -10,6 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data:
-  netrc: {{ .Values.netrc | b64enc }}
+stringData:
+  netrc: {{ .Values.netrc }}
 {{- end }}

--- a/charts/atlantis/templates/secret-redis.yaml
+++ b/charts/atlantis/templates/secret-redis.yaml
@@ -10,6 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data:
-  password: {{ .Values.redis.password | b64enc }}
+stringData:
+  password: {{ .Values.redis.password }}
 {{- end }}

--- a/charts/atlantis/templates/secret-webhook.yaml
+++ b/charts/atlantis/templates/secret-webhook.yaml
@@ -10,31 +10,31 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data:
+stringData:
   {{- if .Values.githubApp }}
-  key.pem: {{ required "githubApp.key is required if githubApp configuration is specified." .Values.githubApp.key | b64enc }}
-  github_secret: {{ required "githubApp.secret is required if githubApp configuration is specified." .Values.githubApp.secret | b64enc }}
+  key.pem: {{ required "githubApp.key is required if githubApp configuration is specified." .Values.githubApp.key }}
+  github_secret: {{ required "githubApp.secret is required if githubApp configuration is specified." .Values.githubApp.secret }}
   {{- end }}
   {{- if .Values.github.user }}
-  github_token: {{ required "github.token is required if github configuration is specified." .Values.github.token | b64enc }}
-  github_secret: {{ required "github.secret is required if github configuration is specified." .Values.github.secret | b64enc }}
+  github_token: {{ required "github.token is required if github configuration is specified." .Values.github.token }}
+  github_secret: {{ required "github.secret is required if github configuration is specified." .Values.github.secret }}
   {{- end }}
   {{- if .Values.gitea }}
-  gitea_token: {{ required "gitea.token is required if gitea configuration is specified." .Values.gitea.token | b64enc }}
-  gitea_secret: {{ required "gitea.secret is required if gitea configuration is specified." .Values.gitea.secret | b64enc }}
+  gitea_token: {{ required "gitea.token is required if gitea configuration is specified." .Values.gitea.token }}
+  gitea_secret: {{ required "gitea.secret is required if gitea configuration is specified." .Values.gitea.secret }}
   {{- end }}
   {{- if .Values.gitlab }}
-  gitlab_token: {{ required "gitlab.token is required if gitlab configuration is specified." .Values.gitlab.token | b64enc }}
-  gitlab_secret: {{ required "gitlab.secret is required if gitlab configuration is specified." .Values.gitlab.secret | b64enc }}
+  gitlab_token: {{ required "gitlab.token is required if gitlab configuration is specified." .Values.gitlab.token }}
+  gitlab_secret: {{ required "gitlab.secret is required if gitlab configuration is specified." .Values.gitlab.secret }}
   {{- end }}
   {{- if .Values.bitbucket }}
-  bitbucket_token: {{ required "bitbucket.token is required if bitbucket configuration is specified." .Values.bitbucket.token | b64enc }}
+  bitbucket_token: {{ required "bitbucket.token is required if bitbucket configuration is specified." .Values.bitbucket.token }}
   {{- if .Values.bitbucket.baseURL }}
-  bitbucket_secret: {{ required "bitbucket.secret is required if bitbucket.baseURL is specified." .Values.bitbucket.secret | b64enc }}
+  bitbucket_secret: {{ required "bitbucket.secret is required if bitbucket.baseURL is specified." .Values.bitbucket.secret }}
   {{- end }}
   {{- end }}
   {{- if .Values.azuredevops }}
-  azuredevops_token: {{ required "azuredevops.token is required if azuredevops configuration is specified." .Values.azuredevops.token | b64enc }}
-  azuredevops_webhook_password: {{ required "azuredevops.webhookPassword is required if azuredevops configuration is specified." .Values.azuredevops.webhookPassword | b64enc }}
+  azuredevops_token: {{ required "azuredevops.token is required if azuredevops configuration is specified." .Values.azuredevops.token }}
+  azuredevops_webhook_password: {{ required "azuredevops.webhookPassword is required if azuredevops configuration is specified." .Values.azuredevops.webhookPassword }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## what


This PR replaces the use of "data" to use "stringData" for the secrets


## why


This allows postrendering script to work as it can parse the secrets values and replace them, For example helmfile vals
https://github.com/helmfile/vals

## tests

- test run manually by comparing secrets values before and after the changed

## references

- (https://github.com/helmfile/vals)

