### PR TITLE
Adapt labels to kubernetes recommended ones

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.47.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.15.0
+version: 6.16.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -21,6 +21,7 @@
   - [Install Helm Chart](#install-helm-chart)
 - [Required Configuration](#required-configuration)
 - [Additional manifests](#additional-manifests)
+- [Labels](#labels)
 - [Values](#values)
 - [Upgrading](#upgrading)
   - [From `4.*` to `5.*`](#from-4-to-5)
@@ -236,6 +237,12 @@ extraManifests:
 ```
 
 Then point the browser-facing Ingress host at the `atlantis-ui` service port (`8080`) while the webhook URL configured in your VCS continues to hit the default port. If you prefer a single port instead, route everything through the proxy and let webhooks bypass auth with `skip_auth_routes=["POST=^/events$"]`.
+
+## Labels
+
+Starting in `6.16.0`, this chart applies the [Kubernetes-recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) (`app.kubernetes.io/name`, `app.kubernetes.io/instance`, `app.kubernetes.io/managed-by`, `app.kubernetes.io/version`) on all resources, in addition to the legacy labels (`app`, `chart`, `release`, `heritage`) that were already there.
+
+Both sets of labels are kept side by side for now, and selectors are left untouched, so this is a non-breaking change. The legacy labels will be removed in a future major release once users have had time to migrate any tooling that depends on them.
 
 ## Values
 

--- a/charts/atlantis/README.md.gotmpl
+++ b/charts/atlantis/README.md.gotmpl
@@ -14,6 +14,7 @@
   - [Install Helm Chart](#install-helm-chart)
 - [Required Configuration](#required-configuration)
 - [Additional manifests](#additional-manifests)
+- [Labels](#labels)
 - [Values](#values)
 - [Upgrading](#upgrading)
   - [From `4.*` to `5.*`](#from-4-to-5)
@@ -229,6 +230,12 @@ extraManifests:
 ```
 
 Then point the browser-facing Ingress host at the `atlantis-ui` service port (`8080`) while the webhook URL configured in your VCS continues to hit the default port. If you prefer a single port instead, route everything through the proxy and let webhooks bypass auth with `skip_auth_routes=["POST=^/events$"]`.
+
+## Labels
+
+Starting in `6.16.0`, this chart applies the [Kubernetes-recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) (`app.kubernetes.io/name`, `app.kubernetes.io/instance`, `app.kubernetes.io/managed-by`, `app.kubernetes.io/version`) on all resources, in addition to the legacy labels (`app`, `chart`, `release`, `heritage`) that were already there.
+
+Both sets of labels are kept side by side for now, and selectors are left untouched, so this is a non-breaking change. The legacy labels will be removed in a future major release once users have had time to migrate any tooling that depends on them.
 
 {{ template "chart.valuesSection" . }}
 

--- a/charts/atlantis/templates/_helpers.tpl
+++ b/charts/atlantis/templates/_helpers.tpl
@@ -140,6 +140,12 @@ chart: {{ template "atlantis.chart" . }}
 helm.sh/chart: {{ template "atlantis.chart" . }}
 release: {{ .Release.Name }}
 heritage: {{ .Release.Service }}
+app.kubernetes.io/name: {{ template "atlantis.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end }}
 {{- if .Values.commonLabels}}
 {{ toYaml .Values.commonLabels }}
 {{- end }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -29,6 +29,8 @@ spec:
       labels:
         app: {{ template "atlantis.name" . }}
         release: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "atlantis.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         {{- if .Values.podTemplate.labels }}
         {{- toYaml .Values.podTemplate.labels | nindent 8 }}
         {{- end }}

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -32,6 +32,18 @@ tests:
       - equal:
           path: metadata.labels.release
           value: my-release
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: atlantis
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: my-release
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: test-appVersion
       - notExists:
           path: metadata.annotations
       - equal:
@@ -51,6 +63,8 @@ tests:
           value:
             app: atlantis
             release: my-release
+            app.kubernetes.io/name: atlantis
+            app.kubernetes.io/instance: my-release
       - equal:
           path: spec.template.metadata.annotations
           value:


### PR DESCRIPTION
## what

- Set Kubernetes recommended labels.


## why

- Align standards.

## tests

- I've testes it by rendering the helm chart.

