### PR TITLE
Use ATLANTIS_DEFAULT_TF_DISTRIBUTION instead of deprecated ATLANTIS_TF_DISTRIBUTION

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.33.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.15.0
+version: 5.16.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -309,7 +309,7 @@ spec:
             value: {{ .Values.defaultTFVersion }}
           {{- end }}
           {{- if .Values.defaultTFDistribution }}
-          - name: ATLANTIS_TF_DISTRIBUTION
+          - name: ATLANTIS_DEFAULT_TF_DISTRIBUTION
             value: {{ .Values.defaultTFDistribution }}
           {{- end }}
           {{- if .Values.logLevel }}

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -119,7 +119,7 @@ tests:
           value:
             - name: PATH
               value: /plugins:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-            - name: ATLANTIS_TF_DISTRIBUTION
+            - name: ATLANTIS_DEFAULT_TF_DISTRIBUTION
               value: terraform
             - name: ATLANTIS_DATA_DIR
               value: /atlantis-data
@@ -186,7 +186,7 @@ tests:
           value:
             - name: PATH
               value: /plugins:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-            - name: ATLANTIS_TF_DISTRIBUTION
+            - name: ATLANTIS_DEFAULT_TF_DISTRIBUTION
               value: terraform
             - name: ATLANTIS_DATA_DIR
               value: /atlantis-data
@@ -1116,7 +1116,7 @@ tests:
           value:
             - name: PATH
               value: /foo:/bar:/plugins:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-            - name: ATLANTIS_TF_DISTRIBUTION
+            - name: ATLANTIS_DEFAULT_TF_DISTRIBUTION
               value: terraform
             - name: ATLANTIS_DATA_DIR
               value: /atlantis-data
@@ -1136,7 +1136,7 @@ tests:
           value:
             - name: PATH
               value: /home/atlantis:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-            - name: ATLANTIS_TF_DISTRIBUTION
+            - name: ATLANTIS_DEFAULT_TF_DISTRIBUTION
               value: terraform
             - name: ATLANTIS_DATA_DIR
               value: /atlantis-data
@@ -1157,7 +1157,7 @@ tests:
           value:
             - name: PATH
               value: /foo:/bar:/home/atlantis:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-            - name: ATLANTIS_TF_DISTRIBUTION
+            - name: ATLANTIS_DEFAULT_TF_DISTRIBUTION
               value: terraform
             - name: ATLANTIS_DATA_DIR
               value: /atlantis-data


### PR DESCRIPTION
## what

Use ATLANTIS_DEFAULT_TF_DISTRIBUTION instead of deprecated ATLANTIS_TF_DISTRIBUTION

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
Fixes #453

