### PR TITLE
docs(values.yaml): better docstring for `apiSecretName`, clearly state required key

### DIFF
--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -271,7 +271,7 @@ api: {}
 # api:
 #   secret: "s3cr3t"
 
-# -- If managing secrets outside the chart for the API secret, use this variable to reference the secret name.
+# -- If managing secrets outside the chart for the API secret, use this variable to reference the secret name. The key containing the secret must be called 'apisecret'.
 apiSecretName: ""
 
 # -- Override the command field of the Atlantis container.


### PR DESCRIPTION
## What / Why

Update the docstring on `apiSecretName`, since it has a hardcoded key we may as well tell the user what the expected key value is. Otherwise the user has to reverse engineer the expected key by looking into the chart templates.

before:
```
# -- If managing secrets outside the chart for the API secret, use this variable to reference the secret name.
apiSecretName: ""
```

after: 

```
# -- If managing secrets outside the chart for the API secret, use this variable to reference the secret name. The key containing the secret must be called 'apisecret'.
apiSecretName: ""
```

## references

- [Where this key is defined](https://github.com/runatlantis/helm-charts/blob/c9801fa652a77af16df68c566ab6d436a8ad16c0/charts/atlantis/templates/statefulset.yaml#L484)