### PR TITLE
chore: remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
similar to what we did with the main atlantis repo, https://github.com/runatlantis/atlantis/pull/2807 and we can remove the dependabot in favor of renovate usage now

also it has been paused for quite some time.
<img width="1524" alt="image" src="https://github.com/user-attachments/assets/d21feabb-8574-4281-976c-a3594e9455f7" />
