### PR TITLE
fix one instance of values.yaml pointing to wrong place

### DIFF
--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -48,7 +48,7 @@ In order for Atlantis to start and run successfully:
     - `bitbucket`
     - `azuredevops`
 
-    Refer to [values.yaml](/charts/atlantis/values.yaml) for detailed examples.
+    Refer to [values.yaml](https://github.com/runatlantis/helm-charts/blob/main/charts/atlantis/values.yaml) for detailed examples.
     They can also be provided directly through a Kubernetes `Secret`, use the variable `vcsSecretName` to reference it.
 
 1. Supply a value for `orgAllowlist`, e.g. `github.com/myorg/*`.

--- a/charts/atlantis/README.md.gotmpl
+++ b/charts/atlantis/README.md.gotmpl
@@ -41,7 +41,7 @@ In order for Atlantis to start and run successfully:
     - `bitbucket`
     - `azuredevops`
 
-    Refer to [values.yaml](/charts/atlantis/values.yaml) for detailed examples.
+    Refer to [values.yaml](https://github.com/runatlantis/helm-charts/blob/main/charts/atlantis/values.yaml) for detailed examples.
     They can also be provided directly through a Kubernetes `Secret`, use the variable `vcsSecretName` to reference it.
 
 1. Supply a value for `orgAllowlist`, e.g. `github.com/myorg/*`.


### PR DESCRIPTION
## what

replace relative ref to `values.yaml` with full external link

I assume there is likely an even more improved way to do this, and am very open to making updates here with some guidance.

Second, there is another instance of this same issue under the `customization` heading: https://runatlantis.github.io/helm-charts/#customization however I haven't figured out where that is 'coming from'


## why

Currently, the `values.yaml` as interpreted on the docs visible here:https://runatlantis.github.io/helm-charts/ are pointing to https://runatlantis.github.io/charts/atlantis/values.yaml & returning a 404

<img width="1369" height="821" alt="Screenshot 2025-07-22 at 10 44 37 PM" src="https://github.com/user-attachments/assets/a6ae729e-6d73-4a30-a64b-7cdc9e1a003e" />


## tests

<!--
- [ ] I have tested my changes by ...
-->

## references
 closes issue opened in runatlantis/atlantis project: https://github.com/runatlantis/atlantis/issues/5675
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

