### PR TITLE
the referenced file DNE on the gh-pages branch, use hard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In order for Atlantis to start and run successfully:
     - `bitbucket`
     - `azuredevops`
 
-    Refer to [values.yaml](/charts/atlantis/values.yaml) for detailed examples.
+    Refer to [values.yaml](https://github.com/runatlantis/helm-charts/blob/main/charts/atlantis/values.yaml) for detailed examples.
     They can also be provided directly through a Kubernetes `Secret`, use the variable `vcsSecretName` to reference it.
 
 1. Supply a value for `orgAllowlist`, e.g. `github.com/myorg/*`.
@@ -53,7 +53,7 @@ extraManifests:
 ```
 
 ## Customization
-The following options are supported. See [values.yaml](/charts/atlantis/values.yaml) for more detailed documentation and examples:
+The following options are supported. See [values.yaml](https://github.com/runatlantis/helm-charts/blob/main/charts/atlantis/values.yaml) for more detailed documentation and examples:
 
 | Parameter                                           | Description                                                                                                                                                                                                                                                                                                 | Default               |
 |-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|


### PR DESCRIPTION
## what

replace relative ref to values.yaml with full external link because this branch doesn't have any of the other files, including the referenced `charts/atlantis/values.yaml` file

## why

Currently, the values.yaml as interpreted on the docs visible here:https://runatlantis.github.io/helm-charts/ are pointing to https://runatlantis.github.io/charts/atlantis/values.yaml & returning a 404

<img width="1369" height="821" alt="Screenshot 2025-07-22 at 10 44 37 PM" src="https://github.com/user-attachments/assets/d6c71f50-89f1-4fb0-b9a6-ac113196faf1" />


## tests

<!--
- [ ] I have tested my changes by ...
-->

## references

closes issue opened in runatlantis/atlantis project: https://github.com/runatlantis/atlantis/issues/5675

I also noticed these docs are pretty out of date compared to the `README.md` on the main branch, however as this is my first contribution to this repo, I figured it's best to start small. On maintainers desire, I can do a fuller copy to this `gh-pages` branch

