### PR TITLE
fix(json-schema): update extraArgs definition

### DIFF
--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1159,19 +1159,6 @@
     },
     "extraAnnotations": {
       "type": "object",
-      "description": "Add additional annotations to all ",
-      "items": {
-        "type": "object"
-      },
-      "examples": [
-        [
-          "--disable-autoplan",
-          "--disable-repo-locking"
-        ]
-      ]
-    },
-    "extraArgs": {
-      "type": "array",
       "description": "These annotations will be added to all the resources",
       "items": {
         "type": "string"
@@ -1179,6 +1166,18 @@
       "examples": {
         "team": "example"
       }
+    },
+    "extraArgs": {
+      "type": "array",
+      "description": "Optionally specify extra arguments for the Atlantis pod.",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "examples": [
+        "--disable-autoplan",
+        "--disable-repo-locking"
+      ]
     },
     "extraContainers": {
       "description": "Additional containers to use and depends of use cases.",


### PR DESCRIPTION
## what

Update the Helm chart's JSON schema `extraArgs` and `extraAnnotations` definition.

## why

The "examples" and "type" definition of the `extraArgs` property seems to have been swapped with the `extraAnnotations` definition. This was causing certain workflows that rely on the JSON-Schema correctness to fail.

## tests

- [x] I have tested my changes by using `helm template` and verifying the chart renders correctly as follows:

```
helm template charts/atlantis -n atlantis --set 'extraArgs={foo,bar,baz},extraAnnotations.team=quux.foo'
 
helm template charts/atlantis -n atlantis --set 'extraArgs[0]=foo,extraAnnotations.team=quux.bar'
```

```
helm template charts/atlantis -n atlantis --set 'extraArgs.foo=bar'                                                                                                                                                                                                                                                     1
coalesce.go:237: warning: skipped value for atlantis.extraArgs: Not a table.
Error: values don't meet the specifications of the schema(s) in the following chart(s):
atlantis:
- extraArgs: Invalid type. Expected: array, given: object
```

## references

N/A
