### PR TITLE
fix: unwritable .aws directory

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.35.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.18.1
+version: 5.18.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.46.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.10.0
+version: 6.10.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -130,6 +130,10 @@ spec:
         secret:
           secretName: {{ .Values.netrcSecretName }}
       {{- end }}
+      {{- if or .Values.aws.credentials .Values.aws.config }}
+      - name: aws-dir
+        emptyDir: {}
+      {{- end }}
       {{- if or .Values.aws.credentials .Values.aws.config .Values.awsSecretName }}
       - name: aws-volume
         secret:
@@ -584,10 +588,23 @@ spec:
             mountPath: /home/atlantis/.netrc
             subPath: netrc
           {{- end }}
-          {{- if or .Values.aws.credentials .Values.aws.config .Values.awsSecretName }}
+          {{- if .Values.awsSecretName }}
           - name: aws-volume
             readOnly: true
             mountPath: {{ .Values.aws.directory | default "/home/atlantis/.aws" }}
+          {{- else if or .Values.aws.credentials .Values.aws.config }}
+          - name: aws-dir
+            mountPath: {{ .Values.aws.directory | default "/home/atlantis/.aws" }}
+          {{- end }}
+          {{- if .Values.aws.credentials }}
+          - name: aws-volume
+            mountPath: {{ .Values.aws.directory | default "/home/atlantis/.aws" }}/credentials
+            subPath: credentials
+          {{- end }}
+          {{- if .Values.aws.config }}
+          - name: aws-volume
+            mountPath: {{ .Values.aws.directory | default "/home/atlantis/.aws" }}/config
+            subPath: config
           {{- end }}
           {{- if .Values.tlsSecretName }}
           - name: tls

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -509,15 +509,26 @@ tests:
       - equal:
           path: spec.template.spec.volumes[1]
           value:
+            name: aws-dir
+            emptyDir: {}
+      - equal:
+          path: spec.template.spec.volumes[2]
+          value:
             name: aws-volume
             secret:
               secretName: my-release-atlantis-aws
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[?(@.name == "aws-volume")]
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name == "aws-volume" && @.subPath == "credentials")]
           value:
-            mountPath: /home/atlantis/.aws
+            mountPath: /home/atlantis/.aws/credentials
             name: aws-volume
-            readOnly: true
+            subPath: credentials
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name == "aws-volume" && @.subPath == "config")]
+          value:
+            mountPath: /home/atlantis/.aws/config
+            name: aws-volume
+            subPath: config
   - it: aws directory
     template: statefulset.yaml
     set:


### PR DESCRIPTION
## what

Mounts the AWS `credentials` and `config` secrets as individual files within a writable `.aws` directory, rather than mounting them in a read-only directory.

This PR has no effect if someone mounts an arbitrary AWS secret using `.Values.awsSecretName` because when doing that there is no way for the Chart to know the contents of the secret so it can't know which files to mount. So in this case there is no change of behavior.


## why

The AWS CLI cannot work properly when the `.aws` directory is read-only. This is a problem since this tool is often needed in Terraform projects. For example, a common way to configure the Helm Terraform provider is to pass in an `exec` argument which executes the AWS CLI to get Kubernetes credentials. Without this change, that would be impossible as the AWS CLI would error.

## tests

I tested my changes by deploying this to my cluster which was previously deploying version 5.18.1 of this Helm Chart.

Values:

```yaml
aws:
  config: |
    redacted
  credentials: |
    redacted
```

Before this change:

```
$ kubectl exec -n atlantis atlantis-0 -- aws sts get-caller-identity

[Errno 30] Read-only file system: '/home/atlantis/.aws/cli'
command terminated with exit code 255
```

After this change:

```
$ kubectl exec -n atlantis atlantis-0 -- aws sts get-caller-identity
{
    "UserId": "redacted",
    "Account": "redacted",
    "Arn": "redacted"
}
```

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

closes https://github.com/runatlantis/helm-charts/issues/380
resolves dupe https://github.com/runatlantis/helm-charts/issues/421
