### PR TITLE
fix(json-schema): fix extraAnnotations/examples

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.35.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.18.2
+version: 5.18.3
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1163,9 +1163,9 @@
       "items": {
         "type": "object"
       },
-      "examples": {
-        "team": "example"
-      }
+      "examples": [
+        {"team": "example"}
+      ]
     },
     "extraArgs": {
       "type": "array",


### PR DESCRIPTION
## what

Change `properties/extraAnnotations/examples` type from `object` to `array` to pass the validation against json metachema.


## why

Validation fails both for `values.yaml` and `templates` with error: 
`/properties/extraAnnotations/examples: got object, want array`
```
❯ helm lint .
==> Linting .
[ERROR] values.yaml: "file:///values.schema.json#" is not valid against metaschema: jsonschema validation failed with 'https://json-schema.org/draft/2019-09/schema#'
- at '': 'allOf' failed
  - at '/properties/extraAnnotations': 'allOf' failed
    - at '/properties/extraAnnotations/examples': got object, want array
[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
atlantis:
"file:///values.schema.json#" is not valid against metaschema: jsonschema validation failed with 'https://json-schema.org/draft/2019-09/schema#'
- at '': 'allOf' failed
  - at '/properties/extraAnnotations': 'allOf' failed
    - at '/properties/extraAnnotations/examples': got object, want array

Error: 1 chart(s) linted, 1 chart(s) failed
```

## tests

```
❯ helm lint
==> Linting .

1 chart(s) linted, 0 chart(s) failed
```

## references

closes #485
