### PR TITLE
fix(helm-unittest): support helm 4

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -3,8 +3,8 @@ name: Lint and Test Charts
 on:
   pull_request:
     paths:
-      - 'charts/atlantis/**'
-      - 'ct.yaml'
+      - "charts/atlantis/**"
+      - "ct.yaml"
 
 defaults:
   run:
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
         with:
           # renovate: datasource=docker depName=python
-          python-version: '3.14'
+          python-version: "3.14"
           check-latest: true
 
       - name: Set up chart-testing
@@ -61,10 +61,45 @@ jobs:
             echo "Documentation is up to date." >&2
           fi
 
-      - name: Install helm unittests
+      # - name: Install helm unittests
+      #   if: steps.list-changed.outputs.changed == 'true'
+      #   run: |
+      #     make unit-test-install
+
+      # Required until https://github.com/helm-unittest/helm-unittest/issues/777 is fixed
+      - name: Install helm-unittest plugin with checksum validation
         if: steps.list-changed.outputs.changed == 'true'
+        shell: bash
         run: |
-          make unit-test-install
+          set -euo pipefail
+
+          VERSION="1.0.3" # without v
+          ARCH="$(uname -m)"
+
+          case "${ARCH}" in
+            x86_64)
+              ARCH=amd64
+              SUM="12a9ef198e21166fe5f7487544903d91355b4ea08b1d59220f1543234caf4371"
+            ;;
+            aarch64|arm64)
+              ARCH=arm64
+              SUM="540aec896945e0e26f443b0d1976d556ce0a3bfa7b10255ed1beecc8d2f7a1cc"
+            ;;
+            *)
+              echo "Unsupported arch: ${ARCH}"
+              exit 1
+            ;;
+          esac
+
+          ASSET="helm-unittest-linux-${ARCH}-${VERSION}.tgz"
+
+          wget "https://github.com/helm-unittest/helm-unittest/releases/download/v${VERSION}/${ASSET}"
+          echo "${SUM}  ${ASSET}" | sha256sum -c
+
+          mkdir -p "$(helm env HELM_PLUGINS)/${ASSET%.*}"
+          tar -xzf "${ASSET}" -C "$(helm env HELM_PLUGINS)/${ASSET%.*}"
+
+          helm plugin list
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
@@ -72,7 +107,6 @@ jobs:
           ct lint \
             --config ct.yaml \
             --target-branch ${{ github.event.repository.default_branch }}
-
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docs: ## Build helm chart documentation
 
 .PHONY: unit-test-install
 unit-test-install:
-	@helm plugin list | grep unittest || helm plugin install --version v0.3.6 https://github.com/helm-unittest/helm-unittest
+	@helm plugin list | grep unittest || helm plugin install --version v1.0.3 https://github.com/helm-unittest/helm-unittest
 
 .PHONY: unit-test-run-atlantis
 unit-test-run-atlantis: unit-test-install ## Run unit tests for Atlantis

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.37.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.21.0
+version: 5.21.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/tests/misc_test.yaml
+++ b/charts/atlantis/tests/misc_test.yaml
@@ -9,37 +9,43 @@ release:
 tests:
   - it: ensure namespaces are specified in all resources
     set:
-      config: "dummy"
+      config: dummy
       gitconfigReadOnly: false
-      gitconfig: "dummy"
+      gitconfig: dummy
       initConfig:
         enabled: true
-      repoConfig: "dummy"
+      repoConfig: dummy
       podMonitor:
         enabled: true
       servicemonitor:
         enabled: true
       enableKubernetesBackend: true
       api:
-        secret: "dummy"
+        secret: dummy
       aws:
-        config: "dummy"
+        config: dummy
       basicAuth:
-        username: "dummy"
-        password: "dummy"
-      netrc: "dummy"
+        username: dummy
+        password: dummy
+      netrc: dummy
       redis:
-        password: "dummy"
+        password: dummy
       serviceAccountSecrets:
-        credentials: "dummy"
+        credentials: dummy
       webhook_ingress:
         enabled: true
       extraManifests:
-      - apiVersion: v1
-        kind: Pod
-        metadata:
-          name: dummy
-          namespace: "my-namespace"
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: dummy-manifest
+            namespace: my-namespace
+      extraSecretManifests:
+        - apiVersion: v1
+          kind: Pod
+          metadata:
+            name: dummy-secret
+            namespace: my-namespace
 
     asserts:
       - equal:


### PR DESCRIPTION
## what

- Caused by https://github.com/helm-unittest/helm-unittest/issues/777
- Related to:
  - https://github.com/runatlantis/helm-charts/pull/505#issuecomment-3617293420
  - https://github.com/runatlantis/helm-charts/pull/519

## why

[Helm-unittest](https://github.com/helm-unittest/helm-unittest) is not fully compatible with helm 4, the current fix is to disable the verification of the package contents on install but this is something we don't want to perform this for security reasons.

The current testing flow uses a makefile step that will only install helm-unittest when it's not available, as a temporary fix this PR installs a pinned version while validating the checksum of the file to ensure integrity.

With this new version the namespace test needed a fix.

## tests

Check CI.