### PR TITLE
fix(helm-unittest): revert to 1.0.2

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -73,17 +73,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          VERSION="1.0.3" # without v
+          VERSION="1.0.2" # without v
           ARCH="$(uname -m)"
 
           case "${ARCH}" in
             x86_64)
               ARCH=amd64
-              SUM="12a9ef198e21166fe5f7487544903d91355b4ea08b1d59220f1543234caf4371"
+              SUM="c3fa443e21860549120cc43455e7fe517f80e5878aff4aa3fee8f8b803eb00fa"
             ;;
             aarch64|arm64)
               ARCH=arm64
-              SUM="540aec896945e0e26f443b0d1976d556ce0a3bfa7b10255ed1beecc8d2f7a1cc"
+              SUM="f543a40777e45a63aaf2808a3395e72027a53d3daef10520a9aba65dbf13ff91"
             ;;
             *)
               echo "Unsupported arch: ${ARCH}"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docs: ## Build helm chart documentation
 
 .PHONY: unit-test-install
 unit-test-install:
-	@helm plugin list | grep unittest || helm plugin install --version v1.0.3 https://github.com/helm-unittest/helm-unittest
+	@helm plugin list | grep unittest || helm plugin install --version v1.0.2 https://github.com/helm-unittest/helm-unittest
 
 .PHONY: unit-test-run-atlantis
 unit-test-run-atlantis: unit-test-install ## Run unit tests for Atlantis

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.38.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 5.23.0
+version: 5.23.1
 keywords:
   - terraform
 home: https://www.runatlantis.io


### PR DESCRIPTION
## what

- Caused by https://github.com/helm-unittest/helm-unittest/issues/790
- Related to https://github.com/runatlantis/helm-charts/pull/520

## why

Helm-unittest version 1.0.3 was forcefully pushed and the checksums are not matching anymore. Reverting to a previous stable version.

## tests

Check CI.