### PR TITLE
feat: add support for VolumeAttributeClass to pvc

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.43.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.4.0
+version: 6.5.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -312,6 +312,7 @@ Optionally, set `service.internalTrafficPolicy: Local` or `Cluster` depending on
 | volumeClaim.dataStorage | string | `"5Gi"` | Disk space available to check out repositories. |
 | volumeClaim.enabled | bool | `true` |  |
 | volumeClaim.storageClassName | string | `""` | Storage class name (if possible, use a resizable one). |
+| volumeClaim.volumeAttributesClassName | string | `""` | Volume attributes class name. |
 | webhook_ingress.annotations | object | `{}` | Check values.yaml for examples. |
 | webhook_ingress.enabled | bool | `false` | When true creates a secondary webhook. |
 | webhook_ingress.host | string | `""` |  |

--- a/charts/atlantis/templates/pvc.yaml
+++ b/charts/atlantis/templates/pvc.yaml
@@ -20,4 +20,7 @@ spec:
   {{- if .Values.volumeClaim.storageClassName }}
   storageClassName: {{ .Values.volumeClaim.storageClassName }}
   {{- end }}
+  {{- if .Values.volumeClaim.volumeAttributesClassName }}
+  volumeAttributesClassName: {{ .Values.volumeClaim.volumeAttributesClassName }}
+  {{- end }}
 {{- end }}

--- a/charts/atlantis/tests/pvc_test.yaml
+++ b/charts/atlantis/tests/pvc_test.yaml
@@ -44,3 +44,13 @@ tests:
       - equal:
           path: spec.resources.requests.storage
           value: 10Gi
+
+  - it: volumeAttributesClassName
+    template: pvc.yaml
+    set:
+      volumeClaim:
+        volumeAttributesClassName: "test-volume-attributes-class"
+    asserts:
+      - equal:
+          path: spec.volumeAttributesClassName
+          value: test-volume-attributes-class

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -473,6 +473,8 @@ volumeClaim:
   dataStorage: 5Gi
   # -- Storage class name (if possible, use a resizable one).
   storageClassName: ""
+  # -- Volume attributes class name.
+  volumeAttributesClassName: ""
   accessModes: ["ReadWriteOnce"]
 
 # -- DEPRECATED - Disk space available to check out repositories.


### PR DESCRIPTION
## what
- adds volumeClaim.VolumeAttributeClassName to the pvc template.

## why
- we'd like to use this newer k8s API to manage mutable pvc properties :) 

## tests
- added some unit tests and confirmed they passed :) 

## references
- [VAC Documentation](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/)

