### PR TITLE
fix: don't create an empty `<appname>-webhook` secret with defaults

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.43.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.5.0
+version: 6.5.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/secret-webhook.yaml
+++ b/charts/atlantis/templates/secret-webhook.yaml
@@ -1,4 +1,11 @@
-{{- if not .Values.vcsSecretName }}
+{{- if and (not .Values.vcsSecretName)
+  (or
+    (not (empty .Values.github))
+    (not (empty .Values.gitlab))
+    (not (empty .Values.gitea))
+    (not (empty .Values.githubApp))
+    (not (empty .Values.azuredevops))
+    (not (empty .Values.bitbucket))) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/atlantis/tests/misc_test.yaml
+++ b/charts/atlantis/tests/misc_test.yaml
@@ -12,6 +12,11 @@ tests:
       config: dummy
       gitconfigReadOnly: false
       gitconfig: dummy
+      azuredevops:
+        user: foo
+        token: bar
+        webhookUser: foo
+        webhookPassword: baz
       initConfig:
         enabled: true
       repoConfig: dummy

--- a/charts/atlantis/tests/secret-webhook_test.yaml
+++ b/charts/atlantis/tests/secret-webhook_test.yaml
@@ -7,15 +7,23 @@ release:
 tests:
   - it: default values
     asserts:
-      - isKind:
-          of: Secret
-      - isAPIVersion:
-          of: v1
-      - equal:
-          path: metadata.name
-          value: my-release-atlantis-webhook
-      - isNullOrEmpty:
-          path: data
+      - hasDocuments:
+          count: 0
+  - it: defined repositories and vcsSecretName
+    set:
+      vcsSecretName: foo
+      githubApp:
+        id: 123456
+        key: |
+          -----BEGIN PRIVATE KEY-----
+          ...
+          -----END PRIVATE KEY-----
+      azuredevops:
+        token: bar
+        webhookPassword: baz
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: vcsSecretName
     set:
       vcsSecretName: atlantis-vcs
@@ -196,6 +204,9 @@ tests:
             azuredevops_webhook_password: YmF6
   - it: commonLabels
     set:
+      azuredevops:
+        token: bar
+        webhookPassword: baz
       commonLabels:
         team: infra
     asserts:


### PR DESCRIPTION
## what

Using default values, we get a `<appname>-webhook` secret, with data=null.

We can avoid creating it entirely in this case.

## why

Leaner deployment, avoiding empty resources whenever possible

## tests

- Changed the default secret-webhook test case as the document isn't created
- Ensure the document isn't created whenever `vcsSecretName` is def'd
- Set a repository so labels can be checked (since defaults don't create the resource anymore)

## references

closes #552

