### PR TITLE
feat(atlantis): add service.extraPorts for additional service ports

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.44.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.6.0
+version: 6.7.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -265,6 +265,7 @@ Optionally, set `service.internalTrafficPolicy: Local` or `Cluster` depending on
 | secret.annotations | object | `{}` | Annotations for the Secrets. Check values.yaml for examples. |
 | service.annotations | object | `{}` |  |
 | service.externalTrafficPolicy | string | `nil` |  |
+| service.extraPorts | list | `[]` | [optional] Additional ports to expose on the service, e.g. for an auth proxy sidecar. Each entry is a standard Service port object. |
 | service.internalTrafficPolicy | string | `nil` | [optional] Internal traffic policy for the Service. One of: Cluster, Local. |
 | service.loadBalancerIP | string | `nil` |  |
 | service.loadBalancerSourceRanges | list | `[]` |  |

--- a/charts/atlantis/templates/service.yaml
+++ b/charts/atlantis/templates/service.yaml
@@ -44,6 +44,9 @@ spec:
     {{- end }}
       protocol: TCP
       name: {{ .Values.service.portName }}
+    {{- with .Values.service.extraPorts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     app: {{ template "atlantis.name" . }}
     release: {{ .Release.Name }}

--- a/charts/atlantis/tests/service_test.yaml
+++ b/charts/atlantis/tests/service_test.yaml
@@ -103,3 +103,22 @@ tests:
       - equal:
           path: metadata.labels.team
           value: infra
+  - it: extraPorts
+    set:
+      service:
+        extraPorts:
+          - name: auth-proxy
+            port: 4180
+            protocol: TCP
+            targetPort: auth-proxy
+    asserts:
+      - equal:
+          path: spec.ports[1]
+          value:
+            name: auth-proxy
+            port: 4180
+            protocol: TCP
+            targetPort: auth-proxy
+      - lengthEqual:
+          path: spec.ports
+          count: 2

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -568,6 +568,14 @@
           ],
           "default": 4141
         },
+        "extraPorts": {
+          "description": "Additional ports to expose on the service, e.g. for an auth proxy sidecar.",
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
         "externalTrafficPolicy": {
           "description": "externalTrafficPolicy to set on service.",
           "type": [

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -311,6 +311,8 @@ service:
   nodePort: null
   # -- (int) [optional] Define the port you would like atlantis to run on. Defaults to 4141.
   targetPort: 4141
+  # -- (list) [optional] Additional ports to expose on the service, e.g. for an auth proxy sidecar. Each entry is a standard Service port object.
+  extraPorts: []
   loadBalancerIP: null
   loadBalancerSourceRanges: []
   externalTrafficPolicy: null


### PR DESCRIPTION
## what

- Add an optional `service.extraPorts` value to the atlantis chart. Entries are appended to the Service's `ports` list verbatim (standard Service port objects).
- Renders nothing when the list is empty, so the default Service output is unchanged.
- Updates `values.yaml`, `values.schema.json`, README (helm-docs), and adds a unittest.

## why

- The chart currently renders exactly one Service port (`service.port`/`service.targetPort`) with no way to expose additional ports. Wrapping the chart to front Atlantis with an auth-proxy sidecar (e.g. oauth2-proxy on `:4180`) forces consumers to create a second, parallel Service just to expose the proxy port — the upstream-managed Service can't carry it.
- `extraPorts` lets a single Service expose both the Atlantis app port (for the ServiceMonitor `/metrics` scrape on `portName: atlantis`) and a sidecar port, consolidating to one Service.

## tests

- [x] `helm lint` passes
- [x] `helm unittest` passes (122 tests; added an `extraPorts` case to `tests/service_test.yaml`)
- [x] `helm template` renders the extra port and the empty default is byte-identical to before
- [x] README regenerated with helm-docs

## references

- Additive and backward-compatible; mirrors the common `extraPorts` pattern used by other charts.