### PR TITLE
chore: bump Atlantis chart appVersion to v0.44.1

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 # renovate: datasource=docker depName=ghcr.io/runatlantis/atlantis
-appVersion: v0.44.0
+appVersion: v0.44.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.7.0
+version: 6.7.1
 keywords:
   - terraform
 home: https://www.runatlantis.io


### PR DESCRIPTION
Summary:
- bump the Atlantis chart appVersion to v0.44.1
- bump the chart version to 6.7.1 for the chart release

Notes:
- Follows the Atlantis v0.44.1 release.
