### PR TITLE
feat(atlantis): allow restartPolicy on containers for native sidecars

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.45.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.9.0
+version: 6.9.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -258,6 +258,20 @@ tests:
       - equal:
           path: spec.template.spec.hostNetwork
           value: true
+  - it: native sidecar via initContainers restartPolicy
+    template: statefulset.yaml
+    set:
+      initContainers:
+        - name: sidecar
+          image: busybox:latest
+          restartPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: sidecar
+      - equal:
+          path: spec.template.spec.initContainers[0].restartPolicy
+          value: Always
   - it: serviceAccountName
     template: statefulset.yaml
     set:

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1620,6 +1620,10 @@
           "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
           "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
         },
+        "restartPolicy": {
+          "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is \"Always\". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container.",
+          "type": "string"
+        },
         "securityContext": {
           "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
           "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"


### PR DESCRIPTION
## What

The bundled `charts/atlantis/values.schema.json` carries an older Kubernetes `io.k8s.api.core.v1.Container` definition with `additionalProperties: false` that predates the `restartPolicy` field added to `Container` in Kubernetes **1.28**.

Because both `initContainers` and `extraContainers` `$ref` that definition, declaring an init container as a **native sidecar** (an `initContainers` entry with `restartPolicy: Always`, stable since k8s 1.29) is rejected at render time:

```
at '/initContainers/0': additional properties 'restartPolicy' not allowed
```

The `statefulset.yaml` template already renders `initContainers`/`extraContainers` verbatim via `toYaml`, so the only thing blocking native sidecars is the schema.

## Change

- Add `restartPolicy` (string) to the `io.k8s.api.core.v1.Container` definition in `values.schema.json`. One edit covers both `initContainers` and `extraContainers` since they share the `$ref`.
- Add a `statefulset` unittest asserting an init container with `restartPolicy: Always` renders (and, since helm-unittest validates against the schema, that it now passes validation).
- Bump chart version `6.7.1` → `6.7.2`.

Additive only — default rendering is unchanged.

## Testing

- `helm lint charts/atlantis` ✅
- `helm unittest charts/atlantis` ✅ (123 tests)

## Use case

Running an auth/connectivity sidecar (e.g. oauth2-proxy or cloud-sql-proxy) as a native sidecar so it is Ready before the atlantis container starts and drains after it during shutdown.