### PR TITLE
chore: bump Atlantis chart appVersion to v0.45.0

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 # renovate: datasource=docker depName=ghcr.io/runatlantis/atlantis
-appVersion: v0.44.1
+appVersion: v0.45.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.7.1
+version: 6.8.0
 keywords:
   - terraform
 home: https://www.runatlantis.io


### PR DESCRIPTION
## what

- Bump the Atlantis chart appVersion to `v0.45.0`.
- Bump the chart version to `6.8.0` for the new Atlantis minor release.

## why

- Atlantis `v0.45.0` is published and the chart should default to the latest Atlantis image.

## tests

- [x] `helm lint ./charts/atlantis`
- [x] `helm template atlantis ./charts/atlantis`
- [x] `helm template atlantis ./charts/atlantis -f charts/atlantis/ci/ci-values.yaml`
- [x] `make unit-test-run-atlantis`
- [x] `make docs` produced no README changes

## references

- https://github.com/runatlantis/atlantis/releases/tag/v0.45.0
