### PR TITLE
feat(atlantis): support dnsConfig.options (e.g. ndots)

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.45.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.8.0
+version: 6.9.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -50,17 +50,8 @@ spec:
       {{- fail "dnsPolicy is set to 'None', but dnsConfig is not provided" }}
       {{- end }}
       dnsConfig:
-        nameservers:
-        {{- range .Values.dnsConfig.nameservers }}
-          - {{ . }}
-        {{- end }}
-        {{- if .Values.dnsConfig.searches }}
-        searches:
-        {{- range .Values.dnsConfig.searches }}
-          - {{ . }}
-        {{- end }}
-        {{- end }}
-        {{- end }}
+        {{- toYaml .Values.dnsConfig | nindent 8 }}
+      {{- end }}
       {{- if .Values.hostAliases }}
       hostAliases:
         {{- range .Values.hostAliases }}

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -1521,7 +1521,25 @@
         },
         "searches": {
           "description": "A list of DNS search domains for hostname lookup.",
-          "type": "string"
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "options": {
+          "description": "A list of DNS resolver options (e.g. ndots).",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "type": "array"
         }
       },
       "type": "object",

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -689,6 +689,9 @@ dnsConfig: {}
 #    - 8.8.8.8
 #  searches:
 #    - mydomain.com
+#  options:
+#    - name: ndots
+#      value: "3"
 
 hostNetwork: false
 


### PR DESCRIPTION
## What

The pod `dnsConfig` block in the StatefulSet only rendered `nameservers` and `searches`, silently dropping `options`. As a result there was no way to set `ndots` (or any other resolver option) on the Atlantis pod, even though `dnsConfig` is exposed in `values.yaml`.

This PR:
- Renders the whole `dnsConfig` value with `toYaml`, so every `PodDNSConfig` field (`nameservers`, `searches`, `options`) passes through.
- Adds `options` to the `DnsConfig` definition in `values.schema.json`. The definition has `additionalProperties: false`, so without this it would **reject** an `options` list.
- Fixes the schema's `searches` type from `string` to `array` (the template ranges over it, so a list was always expected).
- Stops emitting an empty `nameservers:` key when only `options`/`searches` are provided.
- Adds an `options`/`ndots` example to the commented `dnsConfig` block in `values.yaml`.

## Why

Tuning `ndots` is a common way to cut unnecessary search-domain lookups (DNS query amplification against kube-dns / NodeLocal DNSCache). It wasn't achievable with this chart without forking.

## Backward compatibility

- `nameservers` / `searches` render identically to before.
- Default `dnsConfig: {}` still renders no `dnsConfig` block.
- `dnsPolicy: "None"` guard (requires `dnsConfig`) is unchanged.

## Testing

`helm lint` clean. Rendered with: options only, nameservers+searches (back-compat), nameservers+searches+options, `dnsPolicy: None` + options, and default (`{}` → no block). All produce valid pod specs.