### PR TITLE
feat(atlantis): add additionalCaCerts to append custom CAs to the trust bundle (non-root)

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.45.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.9.2
+version: 6.10.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -241,6 +241,12 @@ Then point the browser-facing Ingress host at the `atlantis-ui` service port (`8
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalCaCerts.enabled | bool | `false` | Enable appending custom CA certificate(s) to the system trust bundle. |
+| additionalCaCerts.envVars | list | `["SSL_CERT_FILE","GIT_SSL_CAINFO","CURL_CA_BUNDLE","REQUESTS_CA_BUNDLE"]` | Core env vars set on the Atlantis container, pointed at the merged bundle. Covers Go (atlantis, terraform), OpenSSL/C (curl, wget), git and Python requests-based tooling (e.g. checkov, az). |
+| additionalCaCerts.extraEnvVars | list | `[]` | Additional env vars to point at the merged bundle, for extra runtimes that ship in custom images (e.g. NODE_EXTRA_CA_CERTS, AWS_CA_BUNDLE, CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE). Harmless if the tool is absent. |
+| additionalCaCerts.image | string | `""` | Image used by the init container that builds the merged CA bundle. Defaults to the Atlantis image so the system CA set matches the app exactly and no extra image needs to be pulled/mirrored. |
+| additionalCaCerts.mountPath | string | `"/ca-certs/ca-certificates.crt"` | Path the merged CA bundle is written to (inside a shared emptyDir). |
+| additionalCaCerts.secretName | string | `""` | Name of a secret containing one or more `*.crt` PEM files to trust. The secret has to be created manually. Every key ending in `.crt` is appended. |
 | affinity | object | `{}` |  |
 | allowDraftPRs | bool | `false` | Enables atlantis to run on a draft Pull Requests. |
 | allowForkPRs | bool | `false` | Enables atlantis to run on a fork Pull Requests. |

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -157,6 +157,13 @@ spec:
         secret:
           secretName: {{ .Values.customPem }}
       {{- end }}
+      {{- if .Values.additionalCaCerts.enabled }}
+      - name: additional-ca-certs
+        secret:
+          secretName: {{ .Values.additionalCaCerts.secretName }}
+      - name: ca-certs-bundle
+        emptyDir: {}
+      {{- end }}
       {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}
@@ -178,10 +185,39 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if or .Values.initContainers .Values.initConfig.enabled }}
+      {{- if or .Values.initContainers .Values.initConfig.enabled .Values.additionalCaCerts.enabled }}
       initContainers:
         {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.additionalCaCerts.enabled }}
+        - name: build-ca-bundle
+          image: "{{ .Values.additionalCaCerts.image | default (printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion)) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              dest="{{ .Values.additionalCaCerts.mountPath }}"
+              mkdir -p "$(dirname "$dest")"
+              # Start from the image's system CA bundle so public CAs are preserved.
+              cat /etc/ssl/certs/ca-certificates.crt > "$dest"
+              # Append every custom CA certificate provided via the secret.
+              for crt in /custom-ca-certs/*.crt; do
+                [ -e "$crt" ] || continue
+                printf '\n' >> "$dest"
+                cat "$crt" >> "$dest"
+              done
+          volumeMounts:
+            - name: additional-ca-certs
+              mountPath: /custom-ca-certs
+              readOnly: true
+            - name: ca-certs-bundle
+              mountPath: {{ dir .Values.additionalCaCerts.mountPath }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if .Values.initConfig.enabled }}
         - name: init-config
@@ -245,6 +281,12 @@ spec:
           {{- end }}
           {{- end }}
           env:
+          {{- if .Values.additionalCaCerts.enabled }}
+          {{- range concat .Values.additionalCaCerts.envVars .Values.additionalCaCerts.extraEnvVars }}
+          - name: {{ . }}
+            value: {{ $.Values.additionalCaCerts.mountPath | quote }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.environmentRaw }}
           {{- with .Values.environmentRaw }}
           {{- toYaml . | nindent 10 }}
@@ -621,6 +663,11 @@ spec:
           - name: additional-trust-certs
             mountPath: /etc/ssl/certs/ca-certificates.crt
             subPath: ca-certificates.crt
+          {{- end }}
+          {{- if .Values.additionalCaCerts.enabled }}
+          - name: ca-certs-bundle
+            mountPath: {{ dir .Values.additionalCaCerts.mountPath }}
+            readOnly: true
           {{- end }}
           {{- if .Values.extraVolumeMounts }}
           {{- toYaml .Values.extraVolumeMounts | nindent 10 }}

--- a/charts/atlantis/tests/additional-ca-certs_test.yaml
+++ b/charts/atlantis/tests/additional-ca-certs_test.yaml
@@ -1,0 +1,116 @@
+---
+suite: test additionalCaCerts
+templates:
+  - configmap-config.yaml
+  - configmap-repo-config.yaml
+  - statefulset.yaml
+chart:
+  appVersion: test-appVersion
+release:
+  name: my-release
+tests:
+  - it: disabled by default renders nothing
+    template: statefulset.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name=="additional-ca-certs")]
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name=="ca-certs-bundle")]
+      - notExists:
+          path: spec.template.spec.containers[0].env[?(@.name=="SSL_CERT_FILE")]
+
+  - it: enabled renders init container, volumes, env vars and mount
+    template: statefulset.yaml
+    set:
+      additionalCaCerts:
+        enabled: true
+        secretName: my-ca
+    asserts:
+      # Secret volume referencing the provided secret
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: additional-ca-certs
+            secret:
+              secretName: my-ca
+      # Shared emptyDir for the merged bundle
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-certs-bundle
+            emptyDir: {}
+      # Init container builds the merged bundle
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: build-ca-bundle
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: ghcr.io/runatlantis/atlantis:test-appVersion
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: additional-ca-certs
+            mountPath: /custom-ca-certs
+            readOnly: true
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: ca-certs-bundle
+            mountPath: /ca-certs
+      # Core trust env vars on the main container, pointing at the merged bundle
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSL_CERT_FILE
+            value: /ca-certs/ca-certificates.crt
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GIT_SSL_CAINFO
+            value: /ca-certs/ca-certificates.crt
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CURL_CA_BUNDLE
+            value: /ca-certs/ca-certificates.crt
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REQUESTS_CA_BUNDLE
+            value: /ca-certs/ca-certificates.crt
+      # Merged bundle mounted read-only into the main container
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ca-certs-bundle
+            mountPath: /ca-certs
+            readOnly: true
+
+  - it: honours a custom init container image
+    template: statefulset.yaml
+    set:
+      additionalCaCerts:
+        enabled: true
+        secretName: my-ca
+        image: example.com/ca-builder:1.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: example.com/ca-builder:1.0.0
+
+  - it: appends extraEnvVars in addition to core env vars
+    template: statefulset.yaml
+    set:
+      additionalCaCerts:
+        enabled: true
+        secretName: my-ca
+        extraEnvVars:
+          - NODE_EXTRA_CA_CERTS
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_EXTRA_CA_CERTS
+            value: /ca-certs/ca-certificates.crt

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -920,6 +920,43 @@
       "type": "string",
       "description": "SecretName of the custom `ca-certificates.cert` to override the `/etc/ssl/certs/ca-certificates.crt` with your custom one (self-signed certificates)<br>Secret has to be created manually and shall contain `ca-certificates.crt: PEM`"
     },
+    "additionalCaCerts": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Append custom CA certificate(s) to the system trust bundle (instead of replacing it as `customPem` does) via a non-root init container and trust-related env vars.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable appending custom CA certificate(s) to the system trust bundle."
+        },
+        "secretName": {
+          "type": "string",
+          "description": "Name of a manually-created secret containing one or more `*.crt` PEM files to trust."
+        },
+        "image": {
+          "type": "string",
+          "description": "Image used by the init container that builds the merged CA bundle. Defaults to the Atlantis image."
+        },
+        "mountPath": {
+          "type": "string",
+          "description": "Path the merged CA bundle is written to inside a shared emptyDir."
+        },
+        "envVars": {
+          "type": "array",
+          "description": "Core trust env vars set on the Atlantis container, pointed at the merged bundle.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extraEnvVars": {
+          "type": "array",
+          "description": "Additional env vars to point at the merged bundle for extra runtimes shipped in custom images.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "resources": {
       "type": "object",
       "description": "Resource configuration for atlantis containers.",

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -455,6 +455,37 @@ route:
 # You have to create a secret with the specified name.
 customPem: ""
 
+# additionalCaCerts appends one or more custom CA certificates to the system
+# trust bundle instead of replacing it (as `customPem` does). An init container
+# concatenates the image's system CA bundle with the certificate(s) from the
+# referenced secret into a shared emptyDir, and the Atlantis container is pointed
+# at the merged bundle via the relevant env vars. This works as the default
+# non-root user and keeps the public CAs up to date with the image.
+additionalCaCerts:
+  # -- Enable appending custom CA certificate(s) to the system trust bundle.
+  enabled: false
+  # -- Name of a secret containing one or more `*.crt` PEM files to trust.
+  # The secret has to be created manually. Every key ending in `.crt` is appended.
+  secretName: ""
+  # -- Image used by the init container that builds the merged CA bundle.
+  # Defaults to the Atlantis image so the system CA set matches the app exactly
+  # and no extra image needs to be pulled/mirrored.
+  image: ""
+  # -- Path the merged CA bundle is written to (inside a shared emptyDir).
+  mountPath: /ca-certs/ca-certificates.crt
+  # -- Core env vars set on the Atlantis container, pointed at the merged bundle.
+  # Covers Go (atlantis, terraform), OpenSSL/C (curl, wget), git and Python
+  # requests-based tooling (e.g. checkov, az).
+  envVars:
+    - SSL_CERT_FILE
+    - GIT_SSL_CAINFO
+    - CURL_CA_BUNDLE
+    - REQUESTS_CA_BUNDLE
+  # -- Additional env vars to point at the merged bundle, for extra runtimes that
+  # ship in custom images (e.g. NODE_EXTRA_CA_CERTS, AWS_CA_BUNDLE,
+  # CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE). Harmless if the tool is absent.
+  extraEnvVars: []
+
 # -- Resources for Atlantis.
 # Check values.yaml for examples.
 resources: {}


### PR DESCRIPTION
## what

- Add a new `additionalCaCerts` value to the Atlantis chart that **appends** one or more custom CA certificates to the system trust bundle, instead of **replacing** it (as the existing `customPem` does).
- An init container (defaulting to the Atlantis image) concatenates the image's `/etc/ssl/certs/ca-certificates.crt` with the `*.crt` files from a referenced secret into a shared `emptyDir`.
- The Atlantis container is pointed at the merged bundle via the relevant trust env vars — `SSL_CERT_FILE`, `GIT_SSL_CAINFO`, `CURL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE` — with an `extraEnvVars` escape hatch for additional runtimes shipped in custom images.
- `customPem` is left untouched for backward compatibility.
- Adds `values.schema.json` entries, helm-unittest coverage, regenerated `README.md`, and bumps the chart `version` `6.9.2` → `6.10.0`.

## why

- When Atlantis runs behind a TLS-inspecting proxy/firewall (Azure Firewall application rules, Zscaler, Netskope, …) that re-signs egress traffic with a **private/internal CA**, every outbound TLS call fails with `x509: certificate signed by unknown authority`. This breaks the `atlantis` server and every subprocess it spawns: `terraform`, `git`, `curl`/`wget`, and Python `requests`-based tooling (`checkov`, `az`).
- The existing `customPem` **replaces** the whole `ca-certificates.crt` via a `subPath` mount, which (a) drops every public CA baked into the image — breaking TLS to any host that is *not* re-signed — and (b) is fragile (see #459, pod fails to start).
- `additionalCaCerts` keeps the public CA set intact (and in sync with the image), works as the **default non-root user** (uid 100) — no `update-ca-certificates`, no `runAsUser: 0`, no `hostPath` — and requires no image changes.

## tests

- [x] `helm lint ./charts/atlantis` passes with the feature both disabled (default) and enabled.
- [x] `helm unittest ./charts/atlantis` — full suite passes (127/127), including a new `tests/additional-ca-certs_test.yaml` asserting: nothing rendered when disabled; init container, secret volume, `emptyDir`, env vars and read-only mount rendered when enabled; custom init image override; `extraEnvVars` appended.
- [x] `values.schema.json` validation rejects malformed input (e.g. `additionalCaCerts.enabled=notabool`).
- [x] `README.md` regenerated with helm-docs (v1.14.2).
- [x] Verified end-to-end on a live cluster behind an Azure Firewall doing TLS inspection: reproducing the exact rendered init-container script + env vars as the non-root `atlantis` user, every tool (`atlantis server`, `terraform`, `git`, `curl`, `checkov`/Python `requests`, `az`) failed without the merged bundle and succeeded with it against a firewall-inspected host.

## references

- closes #567
- Revisits #82 (Support custom CA certs) and addresses the replace-style limitation behind #459 (pod fails to start with `customPem`).
