### PR TITLE
chore: bump Atlantis chart appVersion to v0.46.0

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 # renovate: datasource=docker depName=ghcr.io/runatlantis/atlantis
-appVersion: v0.45.0
+appVersion: v0.46.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.9.2
+version: 6.9.3
 keywords:
   - terraform
 home: https://www.runatlantis.io


### PR DESCRIPTION
## Summary

Bumps the Atlantis Helm chart for the Atlantis v0.46.0 release.

- sets chart appVersion to v0.46.0
- bumps chart version to 6.9.3

## References

- https://github.com/runatlantis/atlantis/releases/tag/v0.46.0
