### PR TITLE
feat: probe readiness every 10s instead of 60s

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.46.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.9.3
+version: 6.9.4
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -341,7 +341,7 @@ Then point the browser-facing Ingress host at the `atlantis-ui` service port (`8
 | readinessProbe.enabled | bool | `true` |  |
 | readinessProbe.failureThreshold | int | `5` |  |
 | readinessProbe.initialDelaySeconds | int | `5` |  |
-| readinessProbe.periodSeconds | int | `60` |  |
+| readinessProbe.periodSeconds | int | `10` | Probe readiness frequently: the server typically listens within seconds of start, but with a 60s period the first tick after the initial-delay miss lands at ~65s, leaving a healthy pod unready (and its Service endpointless) for most of a minute on every restart. /healthz is unauthenticated and cheap. Liveness keeps the lazy 60s cadence: it only gates restarts, where a false positive can kill an in-flight apply. |
 | readinessProbe.scheme | string | `"HTTP"` |  |
 | readinessProbe.successThreshold | int | `1` |  |
 | readinessProbe.timeoutSeconds | int | `5` |  |

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -296,7 +296,13 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  periodSeconds: 60
+  # -- Probe readiness frequently: the server typically listens within seconds
+  # of start, but with a 60s period the first tick after the initial-delay miss
+  # lands at ~65s, leaving a healthy pod unready (and its Service endpointless)
+  # for most of a minute on every restart. /healthz is unauthenticated and
+  # cheap. Liveness keeps the lazy 60s cadence: it only gates restarts, where a
+  # false positive can kill an in-flight apply.
+  periodSeconds: 10
   initialDelaySeconds: 5
   timeoutSeconds: 5
   successThreshold: 1


### PR DESCRIPTION
## What
Lower the default `readinessProbe.periodSeconds` from 60 to 10. Liveness is deliberately unchanged. Chart `6.9.3` → `6.9.4`, helm-docs regenerated.

## Why
Both probes default to `periodSeconds: 60` with `initialDelaySeconds: 5`. Atlantis serves `/healthz` within a few seconds of process start, so on every pod (re)start the sequence is:

```
t=5s    first readiness probe — server still booting → miss
t≈10s   server actually listening
t=65s   second probe → finally Ready
```

Result: a healthy pod sits `NotReady` — its Service endpointless, webhooks unroutable (503s from any mesh/LB in front of it) — for most of a minute on every restart, upgrade, or reschedule. We hit this in production behind a service mesh, where the window translates directly into failed GitHub webhook deliveries.

`/healthz` is unauthenticated and trivially cheap (no VCS or state calls), so probing it every 10s adds negligible load while cutting worst-case Ready latency from ~65s to ~15s.

## Why liveness stays at 60s
Liveness only gates restarts, and a false positive there is expensive — it can kill a pod mid-`terraform apply`. With `failureThreshold: 5` the current defaults give a wedged server 5 minutes of grace, which is the right asymmetry for a server running long Terraform operations. The existing comment on the liveness block ("not a high-throughput service") remains true for liveness; readiness has different economics.

## Testing
- `helm lint` clean
- `helm template` renders `periodSeconds: 10` on readiness, `60` on liveness, all sibling fields unchanged
- Running with this configuration on our internal instances (as a values override) — Ready latency dropped from ~65s to ~15s on restart