### PR TITLE
feat(atlantis): support named service ports in ingress backends

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.46.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.10.0
+version: 6.10.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.46.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.10.1
+version: 6.10.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.46.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.10.2
+version: 6.11.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/_helpers.tpl
+++ b/charts/atlantis/templates/_helpers.tpl
@@ -148,3 +148,14 @@ Sets the container port based on the defined values.
 {{- define "atlantis.containerPort" -}}
 {{- default .Values.service.targetPort .Values.containerPort  }}
 {{- end -}}
+
+{{/*
+Render an Ingress service backend port as either a named port or a numbered port.
+*/}}
+{{- define "atlantis.ingressServicePort" -}}
+{{- if kindIs "string" . -}}
+name: {{ . | quote }}
+{{- else -}}
+number: {{ . }}
+{{- end -}}
+{{- end -}}

--- a/charts/atlantis/templates/ingress.yaml
+++ b/charts/atlantis/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
               service:
                 name: {{ .service }}
                 port:
-                  number: {{ .port }}
+                  {{ include "atlantis.ingressServicePort" .port }}
           {{- end }}
         {{ else }}
           - path: {{ .Values.ingress.path }}
@@ -54,7 +54,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ .Values.service.port }}
+                  {{ include "atlantis.ingressServicePort" $svcPort }}
         {{- end }}
     {{ else }}
     {{- range $k := .Values.ingress.hosts }}
@@ -75,7 +75,7 @@ spec:
                 name: {{ $fullName }}
                 {{- end }}
                 port:
-                  number: {{ $svcPort }}
+                  {{ include "atlantis.ingressServicePort" $svcPort }}
         {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/atlantis/templates/webhook-ingress.yaml
+++ b/charts/atlantis/templates/webhook-ingress.yaml
@@ -45,7 +45,7 @@ spec:
               service:
                 name: {{ .service }}
                 port:
-                  number: {{ .port }}
+                  {{ include "atlantis.ingressServicePort" .port }}
           {{- end }}
         {{ else }}
           - path: {{ .Values.webhook_ingress.path }}
@@ -54,7 +54,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ .Values.service.port }}
+                  {{ include "atlantis.ingressServicePort" $svcPort }}
         {{- end }}
     {{ else }}
     {{- range $k := .Values.webhook_ingress.hosts }}
@@ -75,7 +75,7 @@ spec:
                 name: {{ $fullName }}
                 {{- end }}
                 port:
-                  number: {{ $svcPort }}
+                  {{ include "atlantis.ingressServicePort" $svcPort }}
         {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/atlantis/tests/ingress_test.yaml
+++ b/charts/atlantis/tests/ingress_test.yaml
@@ -1,0 +1,31 @@
+---
+suite: test ingress
+templates:
+  - ingress.yaml
+release:
+  name: my-release
+  namespace: default
+tests:
+  - it: renders numeric custom path port
+    set:
+      ingress:
+        paths:
+          - path: /
+            service: custom-service
+            port: 8080
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8080
+
+  - it: renders named custom path port
+    set:
+      ingress:
+        paths:
+          - path: /
+            service: custom-service
+            port: http
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: http

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -764,6 +764,7 @@
                 },
                 "port": {
                   "type": [
+                    "string",
                     "integer",
                     "null"
                   ],


### PR DESCRIPTION
## Description

Adds support for referencing a Kubernetes Service backend by **named port** (in addition to the existing numeric port) in the Atlantis chart Ingress and webhook Ingress templates.

Previously, ingress backend ports were always rendered as `port.number`, which meant users had to switch to the custom `paths` structure just to use a named service port. This change lets the simple/default ingress path stay simple while still allowing a string (named) port.

## Changes

- Add `atlantis.ingressServicePort` helper in `_helpers.tpl` that renders either `name: <string>` or `number: <int>` depending on the value type.
- Use the helper in `templates/ingress.yaml` and `templates/webhook-ingress.yaml` for the default and custom-path backends.
- Allow `string` (named port) in addition to `integer`/`null` for the `port` field in `values.schema.json`.

## Behavior

- Numeric port values render as `port.number` (unchanged, backwards compatible).
- String port values render as `port.name`.
