### PR TITLE
feat(atlantis): add optional PodDisruptionBudget

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.46.0
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.9.3
+version: 6.10.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -335,6 +335,11 @@ Then point the browser-facing Ingress host at the `atlantis-ui` service port (`8
 | nodeSelector | object | `{}` |  |
 | orgAllowlist | string | `"<replace-me>"` | Replace this with your own repo allowlist. |
 | orgWhitelist | string | `"<deprecated>"` | Deprecated in favor of orgAllowlist. |
+| podDisruptionBudget.annotations | object | `{}` | Additional annotations to add to the PodDisruptionBudget. |
+| podDisruptionBudget.enabled | bool | `false` | Whether to create a PodDisruptionBudget for Atlantis. |
+| podDisruptionBudget.labels | object | `{}` | Additional labels to add to the PodDisruptionBudget. |
+| podDisruptionBudget.maxUnavailable | string | `""` | Maximum number or percentage of pods that can be unavailable. When set, it takes precedence over minAvailable. Mutually exclusive with minAvailable. |
+| podDisruptionBudget.minAvailable | int | `1` | Minimum number or percentage of pods that must remain available. Used when maxUnavailable is not set. Mutually exclusive with maxUnavailable. |
 | podMonitor | object | `{"enabled":false,"interval":"30s","metricRelabeling":[]}` | Enable this if you're using Google Managed Prometheus. |
 | podTemplate.annotations | object | `{}` | Check values.yaml for examples. |
 | podTemplate.labels | object | `{}` |  |

--- a/charts/atlantis/templates/pdb.yaml
+++ b/charts/atlantis/templates/pdb.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "atlantis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "atlantis.labels" . | nindent 4 }}
+    {{- with .Values.podDisruptionBudget.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.podDisruptionBudget.annotations .Values.extraAnnotations }}
+  annotations:
+    {{- with .Values.podDisruptionBudget.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "atlantis.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/atlantis/tests/misc_test.yaml
+++ b/charts/atlantis/tests/misc_test.yaml
@@ -24,6 +24,8 @@ tests:
         enabled: true
       servicemonitor:
         enabled: true
+      podDisruptionBudget:
+        enabled: true
       enableKubernetesBackend: true
       api:
         secret: dummy

--- a/charts/atlantis/tests/pdb_test.yaml
+++ b/charts/atlantis/tests/pdb_test.yaml
@@ -1,0 +1,88 @@
+---
+suite: test pod disruption budget
+templates:
+  - pdb.yaml
+release:
+  name: my-release
+tests:
+  - it: is not created by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: default values when enabled
+    set:
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: apiVersion
+          value: policy/v1
+      - equal:
+          path: metadata.name
+          value: my-release-atlantis
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app: atlantis
+            release: my-release
+  - it: minAvailable can be overridden
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+  - it: maxUnavailable takes precedence over minAvailable
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+  - it: supports percentage values
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 50%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 50%
+  - it: labels and annotations
+    set:
+      podDisruptionBudget:
+        enabled: true
+        labels:
+          team: infra
+        annotations:
+          foo: bar
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: infra
+      - equal:
+          path: metadata.annotations.foo
+          value: bar
+  - it: commonLabels
+    set:
+      podDisruptionBudget:
+        enabled: true
+      commonLabels:
+        team: infra
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: infra

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -969,6 +969,37 @@
       "description": "Number of replicas to run for the Atlantis server.",
       "default": 1
     },
+    "podDisruptionBudget": {
+      "type": "object",
+      "description": "Pod disruption budget for the Atlantis StatefulSet.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to create a PodDisruptionBudget for Atlantis",
+          "default": false
+        },
+        "minAvailable": {
+          "type": ["integer", "string"],
+          "description": "Minimum number or percentage of pods that must remain available. Used when maxUnavailable is not set.",
+          "default": 1
+        },
+        "maxUnavailable": {
+          "type": ["integer", "string"],
+          "description": "Maximum number or percentage of pods that can be unavailable. Takes precedence over minAvailable when set."
+        },
+        "labels": {
+          "type": "object",
+          "description": "Additional labels to add to the PodDisruptionBudget",
+          "default": {}
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Additional annotations to add to the PodDisruptionBudget",
+          "default": {}
+        }
+      }
+    },
     "test": {
       "type": "object",
       "description": "Test configuration for atlantis containers.",

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -488,6 +488,24 @@ storageClassName: ""
 # -- Replica count for Atlantis pods.
 replicaCount: 1
 
+# Pod disruption budget for the Atlantis StatefulSet, to keep Atlantis
+# available during voluntary disruptions such as node drains.
+# Note: Atlantis is stateful and typically runs a single replica; enabling a
+# PDB with minAvailable set to 1 will block voluntary evictions of that pod.
+podDisruptionBudget:
+  # -- Whether to create a PodDisruptionBudget for Atlantis.
+  enabled: false
+  # -- Minimum number or percentage of pods that must remain available.
+  # Used when maxUnavailable is not set. Mutually exclusive with maxUnavailable.
+  minAvailable: 1
+  # -- Maximum number or percentage of pods that can be unavailable.
+  # When set, it takes precedence over minAvailable. Mutually exclusive with minAvailable.
+  maxUnavailable: ""
+  # -- Additional labels to add to the PodDisruptionBudget.
+  labels: {}
+  # -- Additional annotations to add to the PodDisruptionBudget.
+  annotations: {}
+
 test:
   # -- Enables test container.
   enabled: true


### PR DESCRIPTION
## what

- Adds a new optional `PodDisruptionBudget` template for the Atlantis StatefulSet, disabled by default.
- Configurable via a new `podDisruptionBudget` values block: `enabled`, `minAvailable`, `maxUnavailable` (mutually exclusive), plus `labels` and `annotations`.
- When `maxUnavailable` is set it takes precedence; otherwise `minAvailable` is used (default `1`). Both accept integers or percentages.
- Includes the JSON schema entry, `helm-unittest` tests, and updated docs/README. Bumps chart version `6.9.3` → `6.10.0`.

## why

- A PodDisruptionBudget is a common, expected resource for production-grade charts and was the main gap here — it lets operators keep Atlantis available during voluntary disruptions such as node drains and cluster upgrades.
- Kept opt-in and off by default so there is no behavior change for existing users. Note is included in `values.yaml` that, because Atlantis is stateful and usually runs a single replica, enabling a PDB with `minAvailable: 1` will block voluntary evictions of that pod.

## tests

- [x] Ran `helm unittest ./charts/atlantis` — 130/130 tests pass across 15 suites, including the new `tests/pdb_test.yaml` (7 cases: disabled-by-default, defaults, `minAvailable` override, `maxUnavailable` precedence, percentage values, labels/annotations, `commonLabels`).
- [x] Ran `helm lint ./charts/atlantis` — passes, confirming the new values validate against `values.schema.json`.
- [x] Verified rendered output for both `minAvailable` and `maxUnavailable` modes via `helm template`.

## references

N/A