### PR TITLE
feat(atlantis): add sharePlanDir for decoupled plan file storage

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.47.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.14.2
+version: 6.15.0
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.47.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.14.1
+version: 6.14.2
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -397,7 +397,12 @@ Then point the browser-facing Ingress host at the `atlantis-ui` service port (`8
 | servicemonitor.interval | string | `"30s"` |  |
 | servicemonitor.metricRelabelings | list | `[]` | Optional metric relabelings to drop or modify metrics. |
 | servicemonitor.path | string | `"/metrics"` |  |
-| sharePlanDir | string | `""` | Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files are stored in the data directory. |
+| sharePlanDir | string | `""` | Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files are stored in the data directory. When sharePlanDirVolumeClaim.enabled is true and this is not set, defaults to /atlantis-plans. |
+| sharePlanDirVolumeClaim.accessModes | list | `["ReadWriteMany"]` | Access modes for the sharePlanDir volume. Use ReadWriteMany for multi-replica deployments. |
+| sharePlanDirVolumeClaim.enabled | bool | `false` | Enable a separate PersistentVolumeClaim mounted at sharePlanDir. When true and sharePlanDir is not set, sharePlanDir defaults to /atlantis-plans. |
+| sharePlanDirVolumeClaim.storage | string | `"5Gi"` | Disk space available for plan file storage. |
+| sharePlanDirVolumeClaim.storageClassName | string | `""` | Storage class name (if possible, use a resizable one). |
+| sharePlanDirVolumeClaim.volumeAttributesClassName | string | `""` | Volume attributes class name. |
 | statefulSet.annotations | object | `{}` |  |
 | statefulSet.labels | object | `{}` |  |
 | statefulSet.priorityClassName | string | `""` |  |

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -397,6 +397,7 @@ Then point the browser-facing Ingress host at the `atlantis-ui` service port (`8
 | servicemonitor.interval | string | `"30s"` |  |
 | servicemonitor.metricRelabelings | list | `[]` | Optional metric relabelings to drop or modify metrics. |
 | servicemonitor.path | string | `"/metrics"` |  |
+| sharePlanDir | string | `""` | Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files are stored in the data directory. |
 | statefulSet.annotations | object | `{}` |  |
 | statefulSet.labels | object | `{}` |  |
 | statefulSet.priorityClassName | string | `""` |  |

--- a/charts/atlantis/README.md
+++ b/charts/atlantis/README.md
@@ -397,9 +397,9 @@ Then point the browser-facing Ingress host at the `atlantis-ui` service port (`8
 | servicemonitor.interval | string | `"30s"` |  |
 | servicemonitor.metricRelabelings | list | `[]` | Optional metric relabelings to drop or modify metrics. |
 | servicemonitor.path | string | `"/metrics"` |  |
-| sharePlanDir | string | `""` | Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files are stored in the data directory. When sharePlanDirVolumeClaim.enabled is true and this is not set, defaults to /atlantis-plans. |
+| sharePlanDir | string | `""` | Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files stay in the data directory and ATLANTIS_SHARE_PLAN_DIR is not set. When sharePlanDirVolumeClaim.enabled is true and this is unset, defaults to /atlantis-plans. |
 | sharePlanDirVolumeClaim.accessModes | list | `["ReadWriteMany"]` | Access modes for the sharePlanDir volume. Use ReadWriteMany for multi-replica deployments. |
-| sharePlanDirVolumeClaim.enabled | bool | `false` | Enable a separate PersistentVolumeClaim mounted at sharePlanDir. When true and sharePlanDir is not set, sharePlanDir defaults to /atlantis-plans. |
+| sharePlanDirVolumeClaim.enabled | bool | `false` | Enable a separate PersistentVolumeClaim mounted at sharePlanDir. When true and sharePlanDir is unset, sharePlanDir defaults to /atlantis-plans. |
 | sharePlanDirVolumeClaim.storage | string | `"5Gi"` | Disk space available for plan file storage. |
 | sharePlanDirVolumeClaim.storageClassName | string | `""` | Storage class name (if possible, use a resizable one). |
 | sharePlanDirVolumeClaim.volumeAttributesClassName | string | `""` | Volume attributes class name. |

--- a/charts/atlantis/templates/_helpers.tpl
+++ b/charts/atlantis/templates/_helpers.tpl
@@ -179,8 +179,8 @@ number: {{ . }}
 {{/*
 Resolves the effective sharePlanDir path.
 If sharePlanDir is set, use it.
-If sharePlanDirVolumeClaim.enabled is true and sharePlanDir is not set, default to /atlantis-plans.
-Otherwise empty (plan files stay in the data directory).
+If sharePlanDirVolumeClaim.enabled is true and sharePlanDir is unset, default to /atlantis-plans.
+Otherwise empty so ATLANTIS_SHARE_PLAN_DIR is not rendered.
 */}}
 {{- define "atlantis.sharePlanDir" -}}
 {{- if .Values.sharePlanDir -}}

--- a/charts/atlantis/templates/_helpers.tpl
+++ b/charts/atlantis/templates/_helpers.tpl
@@ -175,3 +175,17 @@ name: {{ . | quote }}
 number: {{ . }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Resolves the effective sharePlanDir path.
+If sharePlanDir is set, use it.
+If sharePlanDirVolumeClaim.enabled is true and sharePlanDir is not set, default to /atlantis-plans.
+Otherwise empty (plan files stay in the data directory).
+*/}}
+{{- define "atlantis.sharePlanDir" -}}
+{{- if .Values.sharePlanDir -}}
+{{- .Values.sharePlanDir -}}
+{{- else if .Values.sharePlanDirVolumeClaim.enabled -}}
+{{- "/atlantis-plans" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/atlantis/templates/pvc-plan.yaml
+++ b/charts/atlantis/templates/pvc-plan.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.sharePlanDirVolumeClaim.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "atlantis.fullname" . }}-share-plan-dir
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "atlantis.labels" . | nindent 4 }}
+  {{- with .Values.extraAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes: {{ .Values.sharePlanDirVolumeClaim.accessModes | toYaml | nindent 2 }}
+  resources:
+    requests:
+      storage: {{ .Values.sharePlanDirVolumeClaim.storage }}
+  {{- if .Values.sharePlanDirVolumeClaim.storageClassName }}
+  storageClassName: {{ .Values.sharePlanDirVolumeClaim.storageClassName }}
+  {{- end }}
+  {{- if .Values.sharePlanDirVolumeClaim.volumeAttributesClassName }}
+  volumeAttributesClassName: {{ .Values.sharePlanDirVolumeClaim.volumeAttributesClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -79,6 +79,11 @@ spec:
         persistentVolumeClaim:
           claimName: {{ template "atlantis.fullname" . }}-data
       {{- end }}
+      {{- if .Values.sharePlanDirVolumeClaim.enabled }}
+      - name: share-plan-dir
+        persistentVolumeClaim:
+          claimName: {{ template "atlantis.fullname" . }}-share-plan-dir
+      {{- end }}
       {{- if .Values.tlsSecretName }}
       - name: tls
         secret:
@@ -319,9 +324,9 @@ spec:
           {{- end }}
           - name: ATLANTIS_DATA_DIR
             value: {{ .Values.atlantisDataDirectory }}
-          {{- if .Values.sharePlanDir }}
+          {{- with include "atlantis.sharePlanDir" . }}
           - name: ATLANTIS_SHARE_PLAN_DIR
-            value: {{ .Values.sharePlanDir | quote }}
+            value: {{ . | quote }}
           {{- end }}
           - name: ATLANTIS_REPO_ALLOWLIST
             {{- if .Values.orgAllowlist }}
@@ -559,6 +564,10 @@ spec:
           {{- if or .Values.volumeClaim.enabled .Values.dataStorage  }}
           - name: atlantis-data
             mountPath: {{ .Values.atlantisDataDirectory }}
+          {{- end }}
+          {{- if .Values.sharePlanDirVolumeClaim.enabled }}
+          - name: share-plan-dir
+            mountPath: {{ include "atlantis.sharePlanDir" . }}
           {{- end }}
           {{- range $name, $_ := .Values.serviceAccountSecrets }}
           - name: {{ $name }}-volume

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -319,6 +319,10 @@ spec:
           {{- end }}
           - name: ATLANTIS_DATA_DIR
             value: {{ .Values.atlantisDataDirectory }}
+          {{- if .Values.sharePlanDir }}
+          - name: ATLANTIS_SHARE_PLAN_DIR
+            value: {{ .Values.sharePlanDir | quote }}
+          {{- end }}
           - name: ATLANTIS_REPO_ALLOWLIST
             {{- if .Values.orgAllowlist }}
             value: {{ .Values.orgAllowlist | quote }}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -324,9 +324,9 @@ spec:
           {{- end }}
           - name: ATLANTIS_DATA_DIR
             value: {{ .Values.atlantisDataDirectory }}
-          {{- with include "atlantis.sharePlanDir" . }}
+          {{- if or .Values.sharePlanDir .Values.sharePlanDirVolumeClaim.enabled }}
           - name: ATLANTIS_SHARE_PLAN_DIR
-            value: {{ . | quote }}
+            value: {{ include "atlantis.sharePlanDir" . | quote }}
           {{- end }}
           - name: ATLANTIS_REPO_ALLOWLIST
             {{- if .Values.orgAllowlist }}

--- a/charts/atlantis/tests/misc_test.yaml
+++ b/charts/atlantis/tests/misc_test.yaml
@@ -26,6 +26,8 @@ tests:
         enabled: true
       podDisruptionBudget:
         enabled: true
+      sharePlanDirVolumeClaim:
+        enabled: true
       enableKubernetesBackend: true
       api:
         secret: dummy

--- a/charts/atlantis/tests/pvc-plan_test.yaml
+++ b/charts/atlantis/tests/pvc-plan_test.yaml
@@ -1,0 +1,61 @@
+suite: test sharePlanDir pvc
+templates:
+  - pvc-plan.yaml
+chart:
+  appVersion: test-appVersion
+release:
+  name: my-release
+tests:
+  - it: is not created by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: default values when enabled
+    set:
+      sharePlanDirVolumeClaim:
+        enabled: true
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: apiVersion
+          value: v1
+      - equal:
+          path: metadata.name
+          value: my-release-atlantis-share-plan-dir
+      - equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteMany
+      - equal:
+          path: spec.resources.requests.storage
+          value: 5Gi
+  - it: accessModes
+    set:
+      sharePlanDirVolumeClaim:
+        enabled: true
+        accessModes:
+          - ReadWriteOnce
+    asserts:
+      - equal:
+          path: spec.accessModes
+          value:
+            - ReadWriteOnce
+  - it: storage requests
+    set:
+      sharePlanDirVolumeClaim:
+        enabled: true
+        storage: 10Gi
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+  - it: volumeAttributesClassName
+    set:
+      sharePlanDirVolumeClaim:
+        enabled: true
+        volumeAttributesClassName: "test-volume-attributes-class"
+    asserts:
+      - equal:
+          path: spec.volumeAttributesClassName
+          value: test-volume-attributes-class

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -1322,3 +1322,21 @@ tests:
       - equal:
           path: spec.template.spec.dnsConfig.nameservers[0]
           value: my-release.example
+  - it: sharePlanDir sets ATLANTIS_SHARE_PLAN_DIR
+    template: statefulset.yaml
+    set:
+      sharePlanDir: /atlantis-plans
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_SHARE_PLAN_DIR
+            value: /atlantis-plans
+  - it: sharePlanDir omitted by default
+    template: statefulset.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_SHARE_PLAN_DIR
+            value: /atlantis-plans

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -1332,6 +1332,10 @@ tests:
           content:
             name: ATLANTIS_SHARE_PLAN_DIR
             value: /atlantis-plans
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: share-plan-dir
   - it: sharePlanDir omitted by default
     template: statefulset.yaml
     asserts:
@@ -1340,3 +1344,42 @@ tests:
           content:
             name: ATLANTIS_SHARE_PLAN_DIR
             value: /atlantis-plans
+  - it: sharePlanDirVolumeClaim mounts PVC at default path
+    template: statefulset.yaml
+    set:
+      sharePlanDirVolumeClaim:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_SHARE_PLAN_DIR
+            value: /atlantis-plans
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: share-plan-dir
+            persistentVolumeClaim:
+              claimName: my-release-atlantis-share-plan-dir
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: share-plan-dir
+            mountPath: /atlantis-plans
+  - it: sharePlanDirVolumeClaim mounts PVC at custom sharePlanDir
+    template: statefulset.yaml
+    set:
+      sharePlanDir: /mnt/shared/plans
+      sharePlanDirVolumeClaim:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ATLANTIS_SHARE_PLAN_DIR
+            value: /mnt/shared/plans
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: share-plan-dir
+            mountPath: /mnt/shared/plans

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -129,6 +129,8 @@ tests:
               value: "4141"
             - name: ATLANTIS_ATLANTIS_URL
               value: http://
+      - notExists:
+          path: spec.template.spec.containers[0].env[?(@.name == "ATLANTIS_SHARE_PLAN_DIR")]
       - equal:
           path: spec.template.spec.containers[0].livenessProbe
           value:
@@ -1339,14 +1341,42 @@ tests:
   - it: sharePlanDir omitted by default
     template: statefulset.yaml
     asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].env[?(@.name == "ATLANTIS_SHARE_PLAN_DIR")]
       - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: share-plan-dir
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: share-plan-dir
+  - it: sharePlanDirVolumeClaim defaults sharePlanDir to /atlantis-plans
+    template: statefulset.yaml
+    set:
+      sharePlanDirVolumeClaim:
+        enabled: true
+    asserts:
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: ATLANTIS_SHARE_PLAN_DIR
             value: /atlantis-plans
-  - it: sharePlanDirVolumeClaim mounts PVC at default path
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: share-plan-dir
+            persistentVolumeClaim:
+              claimName: my-release-atlantis-share-plan-dir
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: share-plan-dir
+            mountPath: /atlantis-plans
+  - it: sharePlanDirVolumeClaim mounts PVC at sharePlanDir
     template: statefulset.yaml
     set:
+      sharePlanDir: /atlantis-plans
       sharePlanDirVolumeClaim:
         enabled: true
     asserts:

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -931,6 +931,11 @@
       "description": "Directory to store atlantis data.",
       "default": "/atlantis-data"
     },
+    "sharePlanDir": {
+      "type": "string",
+      "description": "Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files are stored in the data directory.",
+      "default": ""
+    },
     "volumeClaim": {
       "type": "object",
       "description": "VolumeClaim configuration for atlantis data.",

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -933,7 +933,7 @@
     },
     "sharePlanDir": {
       "type": "string",
-      "description": "Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files are stored in the data directory. When sharePlanDirVolumeClaim.enabled is true and this is not set, defaults to /atlantis-plans.",
+      "description": "Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files stay in the data directory and ATLANTIS_SHARE_PLAN_DIR is not set. When sharePlanDirVolumeClaim.enabled is true and this is unset, defaults to /atlantis-plans.",
       "default": ""
     },
     "sharePlanDirVolumeClaim": {
@@ -942,7 +942,7 @@
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Enable a separate PersistentVolumeClaim for sharePlanDir. When true and sharePlanDir is not set, sharePlanDir defaults to /atlantis-plans.",
+          "description": "Enable a separate PersistentVolumeClaim for sharePlanDir. When true and sharePlanDir is unset, sharePlanDir defaults to /atlantis-plans.",
           "default": false
         },
         "storage": {

--- a/charts/atlantis/values.schema.json
+++ b/charts/atlantis/values.schema.json
@@ -933,8 +933,41 @@
     },
     "sharePlanDir": {
       "type": "string",
-      "description": "Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files are stored in the data directory.",
+      "description": "Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files are stored in the data directory. When sharePlanDirVolumeClaim.enabled is true and this is not set, defaults to /atlantis-plans.",
       "default": ""
+    },
+    "sharePlanDirVolumeClaim": {
+      "type": "object",
+      "description": "Optional PersistentVolumeClaim mounted at sharePlanDir. Disabled by default.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable a separate PersistentVolumeClaim for sharePlanDir. When true and sharePlanDir is not set, sharePlanDir defaults to /atlantis-plans.",
+          "default": false
+        },
+        "storage": {
+          "type": "string",
+          "description": "Amount of storage available for plan file storage.",
+          "default": "5Gi"
+        },
+        "storageClassName": {
+          "type": "string",
+          "description": "Storage class of the volume mounted for plan file storage."
+        },
+        "volumeAttributesClassName": {
+          "type": "string",
+          "description": "Volume attributes class name."
+        },
+        "accessModes": {
+          "type": "array",
+          "description": "Array of requested access modes for the volume. Use ReadWriteMany for multi-replica deployments.",
+          "items": {
+            "type": "string",
+            "description": "The access mode to be requested."
+          },
+          "default": ["ReadWriteMany"]
+        }
+      }
     },
     "volumeClaim": {
       "type": "object",

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -469,6 +469,9 @@ resources: {}
 # -- Path to the data directory for the volumeMount.
 atlantisDataDirectory: /atlantis-data
 
+# -- Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files are stored in the data directory.
+sharePlanDir: ""
+
 volumeClaim:
   enabled: true
   # -- Disk space available to check out repositories.

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -470,12 +470,12 @@ resources: {}
 atlantisDataDirectory: /atlantis-data
 
 # -- Path to a directory to store Terraform plan files, decoupled from the data directory.
-# When unset, plan files are stored in the data directory.
-# When sharePlanDirVolumeClaim.enabled is true and this is not set, defaults to /atlantis-plans.
+# When unset, plan files stay in the data directory and ATLANTIS_SHARE_PLAN_DIR is not set.
+# When sharePlanDirVolumeClaim.enabled is true and this is unset, defaults to /atlantis-plans.
 sharePlanDir: ""
 
 sharePlanDirVolumeClaim:
-  # -- Enable a separate PersistentVolumeClaim mounted at sharePlanDir. When true and sharePlanDir is not set, sharePlanDir defaults to /atlantis-plans.
+  # -- Enable a separate PersistentVolumeClaim mounted at sharePlanDir. When true and sharePlanDir is unset, sharePlanDir defaults to /atlantis-plans.
   enabled: false
   # -- Disk space available for plan file storage.
   storage: 5Gi

--- a/charts/atlantis/values.yaml
+++ b/charts/atlantis/values.yaml
@@ -469,8 +469,22 @@ resources: {}
 # -- Path to the data directory for the volumeMount.
 atlantisDataDirectory: /atlantis-data
 
-# -- Path to a directory to store Terraform plan files, decoupled from the data directory. When unset, plan files are stored in the data directory.
+# -- Path to a directory to store Terraform plan files, decoupled from the data directory.
+# When unset, plan files are stored in the data directory.
+# When sharePlanDirVolumeClaim.enabled is true and this is not set, defaults to /atlantis-plans.
 sharePlanDir: ""
+
+sharePlanDirVolumeClaim:
+  # -- Enable a separate PersistentVolumeClaim mounted at sharePlanDir. When true and sharePlanDir is not set, sharePlanDir defaults to /atlantis-plans.
+  enabled: false
+  # -- Disk space available for plan file storage.
+  storage: 5Gi
+  # -- Storage class name (if possible, use a resizable one).
+  storageClassName: ""
+  # -- Volume attributes class name.
+  volumeAttributesClassName: ""
+  # -- Access modes for the sharePlanDir volume. Use ReadWriteMany for multi-replica deployments.
+  accessModes: ["ReadWriteMany"]
 
 volumeClaim:
   enabled: true


### PR DESCRIPTION
## Description

Adds support for the `--share-plan-dir` flag (`ATLANTIS_SHARE_PLAN_DIR`) introduced in Atlantis [v0.47.0](https://github.com/runatlantis/atlantis/releases/tag/v0.47.0) via [runatlantis/atlantis#6636](https://github.com/runatlantis/atlantis/pull/6636).

This flag stores Terraform plan files (`.tfplan`) in a directory decoupled from the main data directory. An optional PVC (`sharePlanDirVolumeClaim`) can mount that path so plans survive pod restarts.

Chart defaults do **not** set `ATLANTIS_SHARE_PLAN_DIR`, so existing installs keep storing plans in the data directory.

## `sharePlanDir` matrix

| `sharePlanDir` | `sharePlanDirVolumeClaim.enabled` | `ATLANTIS_SHARE_PLAN_DIR` | PVC mounted | Plans persist across restart |
| --- | --- | --- | --- | --- |
| `""` (default) | `false` (default) | **not set** | no | yes (data dir PVC) |
| `/custom/path` | `false` | `/custom/path` | no | only if you add `extraVolumes` / `extraVolumeMounts` |
| `""` | `true` | `/atlantis-plans` | yes, at `/atlantis-plans` | yes (share-plan-dir PVC) |
| `/custom/path` | `true` | `/custom/path` | yes, at `/custom/path` | yes (share-plan-dir PVC) |

## Changes

- Add `sharePlanDir` value (default `""`) — env var is rendered only when this is set **or** `sharePlanDirVolumeClaim.enabled` is `true`
- Add optional `sharePlanDirVolumeClaim` (default `enabled: false`, `ReadWriteMany`, `5Gi`)
- When the PVC is enabled and `sharePlanDir` is unset, the path defaults to `/atlantis-plans` and the PVC is mounted there
- Add `sharePlanDir` / `sharePlanDirVolumeClaim` to `values.schema.json`
- Document the values in `README.md`
- Bump chart `version` to `6.14.2` (appVersion stays `v0.47.1`)
- Unit tests for default omission, explicit `sharePlanDir`, PVC default path, and custom path + PVC

## Testing

- `helm lint charts/atlantis` passes
- `helm unittest ./charts/atlantis` passes
- `helm template` with default values omits `ATLANTIS_SHARE_PLAN_DIR`
- `helm template` with `sharePlanDirVolumeClaim.enabled=true` sets `ATLANTIS_SHARE_PLAN_DIR=/atlantis-plans` and mounts the PVC