### PR TITLE
fix(atlantis): hash only the config data in checksum/* annotations

### DIFF
--- a/charts/atlantis/Chart.yaml
+++ b/charts/atlantis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: v0.47.1
 description: A Helm chart for Atlantis https://www.runatlantis.io
 name: atlantis
-version: 6.15.0
+version: 6.15.1
 keywords:
   - terraform
 home: https://www.runatlantis.io

--- a/charts/atlantis/templates/_helpers.tpl
+++ b/charts/atlantis/templates/_helpers.tpl
@@ -189,3 +189,11 @@ Otherwise empty so ATLANTIS_SHARE_PLAN_DIR is not rendered.
 {{- "/atlantis-plans" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Compute a ConfigMap or Secret checksum from its data only, for the checksum/* pod annotations.
+The full manifest carries the helm.sh/chart label, which changes on every chart version bump.
+*/}}
+{{- define "atlantis.configMapOrSecretContentHash" -}}
+{{ pick (include (print .ctx.Template.BasePath .name) .ctx | fromYaml) "data" "stringData" | toYaml | sha256sum }}
+{{- end -}}

--- a/charts/atlantis/templates/statefulset.yaml
+++ b/charts/atlantis/templates/statefulset.yaml
@@ -33,10 +33,10 @@ spec:
         {{- toYaml .Values.podTemplate.labels | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}
-        checksum/repo-config: {{ include (print $.Template.BasePath "/configmap-repo-config.yaml") . | sha256sum }}
+        checksum/config: {{ include "atlantis.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmap-config.yaml") }}
+        checksum/repo-config: {{ include "atlantis.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmap-repo-config.yaml") }}
         {{- if .Values.initConfig.enabled }}
-        checksum/init-config: {{ include (print $.Template.BasePath "/configmap-init-config.yaml") . | sha256sum }}
+        checksum/init-config: {{ include "atlantis.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmap-init-config.yaml") }}
         {{- end }}
         {{- if .Values.podTemplate.annotations }}
         {{- toYaml .Values.podTemplate.annotations | nindent 8 }}

--- a/charts/atlantis/tests/statefulset_test.yaml
+++ b/charts/atlantis/tests/statefulset_test.yaml
@@ -54,8 +54,8 @@ tests:
       - equal:
           path: spec.template.metadata.annotations
           value:
-            checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-            checksum/repo-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+            checksum/config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+            checksum/repo-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
       - notExists:
           path: spec.template.spec.hostAliases
       - equal:
@@ -1413,3 +1413,13 @@ tests:
           content:
             name: share-plan-dir
             mountPath: /mnt/shared/plans
+  - it: keeps the config checksums stable across chart versions
+    template: statefulset.yaml
+    chart:
+      version: 99.99.99
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            checksum/config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+            checksum/repo-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a


### PR DESCRIPTION
## what

- `checksum/config`, `checksum/repo-config` and `checksum/init-config` now hash only the `data` of the rendered ConfigMap, through a new `atlantis.configMapOrSecretContentHash` helper
- chart bumped to 6.15.1

## why

- The annotations hashed the whole rendered manifest, and `metadata.labels` include `helm.sh/chart`. That value changes on every chart version bump, so the Atlantis StatefulSet pod was restarted on every `helm upgrade` even when no configuration had changed
- Same fix as argo-cd (argoproj/argo-helm#4044); the loki chart uses the same data-only hashing
- Upgrading to 6.15.1 restarts the pod once, as the annotation values change

## tests

- [x] `helm unittest` passes (150 tests), including a new case asserting the checksums are identical when only the chart version changes
- [x] Rendered `test-values.yaml` against a bumped chart version: checksums unchanged; setting `repoConfig` still changes `checksum/repo-config`
- The two hardcoded hashes in `tests/statefulset_test.yaml` moved from the sha256 of an empty string to the sha256 of `{}`, since the default render produces ConfigMaps with no data

## references

- argoproj/argo-helm#4044